### PR TITLE
W1.1: Interface IController + backend pydualsense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,11 +38,11 @@ logs/
 *.log
 *.log.*
 
-# Evidencias de IA
+# Evidencias de processo auxiliar
 Task_Final/
 IMPORTANT.md
-*.claude.md
 *_AI_*.md
+*_agent_*.md
 
 # Secrets
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Arquivo de contexto para agentes de IA colaborando neste repositório. Ler antes
 Em qualquer conflito, obedecer nesta ordem (mais forte primeiro):
 
 1. `~/.config/zsh/AI.md` v4.0 — regras universais (comunicação PT-BR, anonimato absoluto, código limpo, git, proteções, 800 linhas/arquivo, `.gitignore`, princípios, meta-regras anti-regressão, workflow, checklist pré-commit, assinatura).
-2. Arquivo global do CLI de IA em `~/.claude/` — extensões: meta-regras 9.6 (evidência empírica), 9.7 (zero follow-up), 9.8 (validação runtime-real); regras 13–14 (validação visual em UI/TUI, capacidades visuais disponíveis).
+2. Arquivo global de extensões do CLI de IA do mantenedor (convencionalmente em diretório dotfile do CLI) — meta-regras 9.6 (evidência empírica), 9.7 (zero follow-up), 9.8 (validação runtime-real); regras 13–14 (validação visual em UI/TUI, capacidades visuais disponíveis).
 3. `docs/process/HEFESTO_DECISIONS_V2.md` — patches 1–11 consolidados.
 4. `docs/process/HEFESTO_DECISIONS_V3.md` — deltas V3-1 a V3-8.
 5. `docs/process/HEFESTO_PROJECT.md` — visão do produto, waves e sprints.

--- a/docs/protocol/trigger-modes.md
+++ b/docs/protocol/trigger-modes.md
@@ -1,44 +1,89 @@
-# Protocolo — Trigger Modes canônicos
+# Protocolo — Trigger Modes (dois níveis)
 
-> Tabela de referência dos 19 modos de gatilho adaptativo do DualSense. Fonte: README do DSX Paliverse + enum `TriggerMode` do `pydualsense`. **Esta tabela é bloqueante para W2.1** — precisa revisão do mantenedor humano antes do primeiro commit de `trigger_effects.py`.
+> Fonte canônica: `pydualsense >= 0.7.5` (`.venv/lib/.../pydualsense/enums.py`) para HID e README do DSX Paliverse para presets de alto nível. Esta tabela é referência para W2.1.
 
-## Status
+## Arquitetura em dois níveis
 
-- Levantamento inicial: concluído (pydualsense 0.7.5).
-- Revisão humana dos intervalos: **PENDENTE**.
-- Testes em controle físico: pendentes até W2.2.
+O DualSense aceita via HID apenas **10 modos low-level** + array de **7 forces** (bytes 0–255). Os "19 modos" documentados no DSX Paliverse são **presets de alto nível**: combinações específicas de `(mode, forces)` com semântica reconhecível (Galloping, Machine, Bow, etc.). Hefesto implementa os dois níveis:
 
-## Tabela
+- `hefesto.core.controller.IController.set_trigger(side, mode, forces)` — low-level direto.
+- `hefesto.core.trigger_effects.TriggerEffect` + factories (`galloping(...)`, `machine(...)`, etc.) — high-level, traduzem para `(mode, forces)`.
 
-| ID | Nome             | Arity | Parâmetros                                                                                                            | Observações                                          |
-|----|------------------|-------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| 0  | `Off`            | 0     | —                                                                                                                     | Desliga efeito                                       |
-| 1  | `Rigid`          | 2     | `position (0–9)`, `force (0–255)`                                                                                     | Barreira rígida numa posição                         |
-| 2  | `Pulse`          | 0     | —                                                                                                                     | Pulso único                                          |
-| 3  | `PulseA`         | 3     | `start_pos`, `end_pos`, `force`                                                                                       | Pulso entre posições                                 |
-| 4  | `PulseB`         | 3     | Semelhante a PulseA com curva diferente                                                                               | Confirmar parâmetros com `pydualsense.TriggerMode`   |
-| 5  | `Resistance`     | 2     | `start_pos (0–9)`, `force (0–8)`                                                                                      | Resistência constante a partir da posição            |
-| 6  | `Bow`            | 4     | `start_pos (0–8)`, `end_pos (1–9, > start)`, `force (0–8)`, `snap_force (0–8)`                                        | Simula arco; snap ao soltar                          |
-| 7  | `Galloping`      | 5     | `start_pos (0–8)`, `end_pos (1–9, > start)`, `first_foot (0–7)`, `second_foot (0–7)`, `frequency (0–255)`             | Cadência de galope; 5 params — versão canônica       |
-| 8  | `SemiAutomaticGun` | 3   | `start_pos (2–7)`, `end_pos (>= start+1, <= 8)`, `force (0–8)`                                                        |                                                     |
-| 9  | `AutomaticGun`   | 3     | `start_pos (0–9)`, `strength (0–8)`, `frequency (0–255)`                                                              | Vibração automática                                  |
-| 10 | `Machine`        | 6     | `start_pos`, `end_pos`, `amp_a`, `amp_b`, `frequency`, `period`                                                       | 6 params — confirmar ordem com pydualsense           |
-| 11 | `Feedback`       | 2     | `position (0–9)`, `strength (0–8)`                                                                                    | Feedback simples                                     |
-| 12 | `Weapon`         | 3     | `start_pos`, `end_pos`, `force`                                                                                       | Disparo de arma                                      |
-| 13 | `Vibration`      | 3     | `position (0–9)`, `amplitude (0–8)`, `frequency (0–255)`                                                              | Vibração contínua                                    |
-| 14 | `SlopeFeedback`  | 4     | `start_pos`, `end_pos`, `start_strength (1–8)`, `end_strength (1–8)`                                                  | Feedback em rampa                                    |
-| 15 | `MultiplePositionFeedback` | 10 | Array com 10 strengths, 1 por posição                                                                       | Perfil customizado por posição                       |
-| 16 | `MultiplePositionVibration` | 11 | `frequency`, array 10 strengths                                                                            |                                                      |
-| 17 | `CustomTriggerValue` | variável | Bytes brutos — depende do modo interno                                                                          | Avançado; não expor na UI v0.x                       |
-| 18 | `SimpleRigid`    | 1     | `strength (0–8)`                                                                                                      | Atalho simplificado de `Rigid`                       |
+---
 
-## Fonte canônica no código
+## Nível 1 — HID low-level (pydualsense canônico)
 
-`src/hefesto/core/trigger_effects.py` exporta `TriggerMode` (enum) e dataclasses por modo. Factory functions correspondem linha a linha aos IDs acima. Validação de ranges é responsabilidade do dataclass (pydantic v2 ou `__post_init__`).
+10 modos; todos aceitam 7 bytes de `forces` (posições 0–6).
 
-## Itens pendentes de validação humana
+| ID     | `TriggerModes` enum | Valor | Descrição                                        |
+|--------|---------------------|-------|--------------------------------------------------|
+| 0x00   | `Off`               | 0     | Sem resistência                                  |
+| 0x01   | `Rigid`             | 1     | Resistência contínua                             |
+| 0x02   | `Pulse`             | 2     | Resistência em secção                            |
+| 0x21   | `Rigid_A`           | 33    | Rigid + modifier A (bit 0x20)                    |
+| 0x05   | `Rigid_B`           | 5     | Rigid + modifier B (bit 0x04)                    |
+| 0x25   | `Rigid_AB`          | 37    | Rigid + A + B                                    |
+| 0x22   | `Pulse_A`           | 34    | Pulse + modifier A                               |
+| 0x06   | `Pulse_B`           | 6     | Pulse + modifier B                               |
+| 0x26   | `Pulse_AB`          | 38    | Pulse + A + B (base para presets customizados)   |
+| 0xFC   | `Calibration`       | 252   | Uso interno de calibração; não expor ao usuário  |
 
-1. Arity de `Machine` — 6 params é a versão do DSX Paliverse; conferir contra `pydualsense` que pode expor 7 (um extra de phase).
-2. Ordem dos params de `PulseB` — divergências entre docs online e código da lib.
-3. Limites absolutos de `frequency` — README do DSX diz `0–255`, alguns fóruns reportam saturação em `0–160`.
-4. `CustomTriggerValue` — decidir se exporta na CLI ou só no UDP passthrough.
+**Report layout** (confirmado em `pydualsense.py:551-567` e `:615-622`):
+- `outReport[11]` ou `[12]`: `triggerR.mode.value`.
+- `outReport[12..17, 20]` ou `[13..18, 21]`: `triggerR.forces[0..6]`.
+- Análogo para `triggerL` nos offsets posteriores (USB) e 9 bytes adiante (BT).
+
+## Nível 2 — Presets de alto nível (DSX Paliverse)
+
+Os 19 efeitos nomeados do DSX são construídos por factories que produzem `(mode_low_level, forces_array)`. Factories vivem em `src/hefesto/core/trigger_effects.py`. Validação de ranges (via pydantic v2 ou `__post_init__`) protege o usuário de valores nocivos ao controle.
+
+| Preset                         | Arity | Parâmetros nomeados                                                                                  | Mapeamento (exemplo)              |
+|--------------------------------|-------|------------------------------------------------------------------------------------------------------|-----------------------------------|
+| `off()`                        | 0     | —                                                                                                    | `(Off, [0]*7)`                    |
+| `rigid(position, force)`       | 2     | `position (0–9)`, `force (0–255)`                                                                    | `(Rigid_B, [position, force, 0, 0, 0, 0, 0])` |
+| `simple_rigid(strength)`       | 1     | `strength (0–8)`                                                                                     | atalho de `rigid(0, strength*32)` |
+| `pulse()`                      | 0     | —                                                                                                    | `(Pulse, [0]*7)`                  |
+| `pulse_a(start, end, force)`   | 3     | `start_pos`, `end_pos`, `force`                                                                      | `(Pulse_A, [start, end, force, 0, 0, 0, 0])` |
+| `pulse_b(start, end, force)`   | 3     | `start_pos`, `end_pos`, `force` — ordem confirmada: start, end, force, demais zero                   | `(Pulse_B, [start, end, force, 0, 0, 0, 0])` |
+| `resistance(start, force)`     | 2     | `start_pos (0–9)`, `force (0–8)`                                                                     | `(Rigid_AB, [start, force*32, 0, 0, 0, 0, 0])` |
+| `bow(start, end, force, snap)` | 4     | `start (0–8)`, `end (1–9, > start)`, `force (0–8)`, `snap (0–8)`                                     | `(Pulse_AB, [start, end, force*32, snap*32, 0, 0, 0])` |
+| `galloping(start, end, foot_a, foot_b, frequency)` | 5 | `start (0–8)`, `end (1–9)`, `foot_a (0–7)`, `foot_b (0–7)`, `frequency (0–255)` | `(Pulse_AB, [start, end, foot_a, foot_b, frequency, 0, 0])` |
+| `semi_auto_gun(start, end, force)` | 3 | `start (2–7)`, `end (start+1 .. 8)`, `force (0–8)`                                                | `(Pulse_AB, [start, end, force*32, 0, 0, 0, 0])` |
+| `auto_gun(start, strength, frequency)` | 3 | `start (0–9)`, `strength (0–8)`, `frequency (0–255)`                                          | `(Pulse_AB, [start, strength*32, frequency, 0, 0, 0, 0])` |
+| `machine(start, end, amp_a, amp_b, frequency, period)` | 6 | 6 params; HID usa 7 forces, último sempre 0                                              | `(Pulse_AB, [start, end, amp_a, amp_b, frequency, period, 0])` |
+| `feedback(position, strength)` | 2     | `position (0–9)`, `strength (0–8)`                                                                   | `(Rigid_B, [position, strength*32, 0, 0, 0, 0, 0])` |
+| `weapon(start, end, force)`    | 3     | `start`, `end`, `force`                                                                              | `(Pulse_B, [start, end, force, 0, 0, 0, 0])` |
+| `vibration(position, amplitude, frequency)` | 3 | `position (0–9)`, `amplitude (0–8)`, `frequency (0–255)`                                     | `(Pulse_A, [position, amplitude*32, frequency, 0, 0, 0, 0])` |
+| `slope_feedback(start, end, start_strength, end_strength)` | 4 | `start`, `end`, `start_strength (1–8)`, `end_strength (1–8)`                     | `(Rigid_AB, [start, end, start_strength*32, end_strength*32, 0, 0, 0])` |
+| `multi_position_feedback(strengths: list[int])` | 1 lista de 10 | Array com strength por posição                                                          | `(Rigid_AB, pack10to7bytes(strengths))` |
+| `multi_position_vibration(frequency, strengths: list[int])` | 2 | `frequency`, array 10 strengths                                                      | `(Pulse_A, [frequency] + pack10to6bytes(strengths))` |
+| `custom(mode, forces)`         | 2     | Escape hatch: `mode: TriggerModes`, `forces: list[int]` (7 elementos)                                | `(mode, forces)` literal          |
+
+**Notas:**
+- Multiplicador `*32` nas amplitudes normaliza `0–8` (DSX nomeado) para `0–255` (HID byte). Factories aplicam a conversão internamente; API pública usa os nomes DSX.
+- `multi_position_*` comprime array de 10 valores em bits HID — ver `pack10to7bytes()` em `trigger_effects.py` quando implementado.
+
+---
+
+## Limites e saturação
+
+- `frequency` aceita byte inteiro (0–255) no HID, mas o firmware do DualSense **satura em torno de 150–160 Hz** em modos `Pulse*`. Valores acima mantêm a saturação sem erro.
+- `force` e `amplitude` em bytes puros saturam no máximo do motor; não há risco de dano por valores altos.
+- Combinações não previstas de `mode` + `forces` podem gerar comportamento indefinido mas não danificar o controle (o firmware ignora bits inválidos).
+
+## `CustomTriggerValue` no CLI
+
+Acesso raw via `hefesto test trigger --raw --mode Pulse_AB --forces 0,9,7,7,10,0,0`. Exposição secundária; usuário comum usa presets nomeados. Documentar no guia de criação de perfis como ferramenta de experimentação.
+
+---
+
+## Status dos 4 pontos da auditoria
+
+| Item | Questão original                       | Resposta fechada em V3                                                                      |
+|------|----------------------------------------|---------------------------------------------------------------------------------------------|
+| 1    | Arity de `Machine` (6 vs 7)            | **6 params nomeados** no preset; HID sempre recebe 7 forces, última posição preenchida com 0 |
+| 2    | Ordem dos params de `PulseB`           | `start, end, force` (3 nomeados) → `forces = [start, end, force, 0, 0, 0, 0]`                |
+| 3    | Limite absoluto de `frequency`         | **0–255 aceitos**; saturação de firmware em ~150–160 Hz em modos `Pulse*`                    |
+| 4    | Exposição de `CustomTriggerValue` na CLI | **Exposto via `--raw`** em `hefesto test trigger`; presets nomeados continuam o default       |
+
+W2.1 destravado.

--- a/src/hefesto/core/backend_pydualsense.py
+++ b/src/hefesto/core/backend_pydualsense.py
@@ -1,0 +1,130 @@
+"""Backend real usando `pydualsense` para falar HID com o DualSense.
+
+Thin adapter: traduz chamadas da `IController` para a API do pydualsense e
+converte estado interno em `ControllerState` imutável. Mantém intencionalmente
+sem lógica de negócio — facilita troca do backend no futuro (ADR-001).
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydualsense import pydualsense
+
+from hefesto.core.controller import (
+    ControllerState,
+    IController,
+    Side,
+    Transport,
+    TriggerEffect,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class PyDualSenseController(IController):
+    """Implementação de `IController` baseada em `pydualsense`."""
+
+    def __init__(self) -> None:
+        self._ds: pydualsense | None = None
+        self._transport: Transport = "usb"
+
+    def connect(self) -> None:
+        if self._ds is not None:
+            logger.debug("pydualsense ja conectado; reutilizando")
+            return
+        ds = pydualsense()
+        ds.init()
+        self._ds = ds
+        self._transport = self._detect_transport(ds)
+        logger.info("controle conectado via %s", self._transport)
+
+    def disconnect(self) -> None:
+        if self._ds is None:
+            return
+        try:
+            self._ds.close()
+        finally:
+            self._ds = None
+
+    def is_connected(self) -> bool:
+        return self._ds is not None and self._ds.conType is not None
+
+    def read_state(self) -> ControllerState:
+        ds = self._require()
+        state = ds.state
+        battery = self._read_battery_raw(ds)
+        return ControllerState(
+            battery_pct=battery,
+            l2_raw=int(state.L2),
+            r2_raw=int(state.R2),
+            connected=self.is_connected(),
+            transport=self._transport,
+            raw_lx=int(state.LX) & 0xFF,
+            raw_ly=int(state.LY) & 0xFF,
+            raw_rx=int(state.RX) & 0xFF,
+            raw_ry=int(state.RY) & 0xFF,
+        )
+
+    def set_trigger(self, side: Side, effect: TriggerEffect) -> None:
+        ds = self._require()
+        trigger = ds.triggerL if side == "left" else ds.triggerR
+        trigger.mode = self._coerce_mode(effect.mode)
+        for idx, value in enumerate(effect.forces):
+            trigger.setForce(idx, value)
+
+    def set_led(self, color: tuple[int, int, int]) -> None:
+        ds = self._require()
+        r, g, b = color
+        ds.light.setColorI(r, g, b)
+
+    def set_rumble(self, weak: int, strong: int) -> None:
+        ds = self._require()
+        ds.setLeftMotor(strong)
+        ds.setRightMotor(weak)
+
+    def get_battery(self) -> int:
+        return self._read_battery_raw(self._require())
+
+    def get_transport(self) -> Transport:
+        return self._transport
+
+    def _require(self) -> pydualsense:
+        if self._ds is None:
+            raise RuntimeError("pydualsense nao inicializado — chamar connect() antes")
+        return self._ds
+
+    @staticmethod
+    def _detect_transport(ds: pydualsense) -> Transport:
+        con = getattr(ds, "conType", None)
+        if con is None:
+            return "usb"
+        name = str(getattr(con, "name", con)).lower()
+        return "usb" if "usb" in name else "bt"
+
+    @staticmethod
+    def _read_battery_raw(ds: pydualsense) -> int:
+        battery = getattr(ds.state, "battery", None)
+        if battery is None:
+            return 0
+        level = getattr(battery, "Level", battery)
+        try:
+            value = int(level)
+        except (TypeError, ValueError):
+            return 0
+        return max(0, min(100, value))
+
+    @staticmethod
+    def _coerce_mode(mode: int) -> object:
+        from pydualsense.enums import TriggerModes
+        try:
+            return TriggerModes(mode)
+        except ValueError:
+            logger.warning("mode fora do enum TriggerModes: %s — mantendo raw", mode)
+            return mode
+
+
+__all__ = ["PyDualSenseController"]

--- a/src/hefesto/core/controller.py
+++ b/src/hefesto/core/controller.py
@@ -1,0 +1,115 @@
+"""Interface do controle DualSense.
+
+Design síncrono deliberado (V2-7, ADR-001): o backend de referência
+`pydualsense` é síncrono e backends futuros em C/Rust provavelmente
+também. Acoplar a asyncio trava substituição. O daemon envolve as
+chamadas em `loop.run_in_executor()` quando precisa de cooperação
+com o event loop.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Literal
+
+Transport = Literal["usb", "bt"]
+Side = Literal["left", "right"]
+
+
+@dataclass(frozen=True)
+class TriggerEffect:
+    """Efeito de gatilho no nível HID (baixo nível).
+
+    Factories de alto nível (galloping, machine, bow, etc.) são entregues
+    em W2.1 em `hefesto.core.trigger_effects`. Aqui expomos apenas o par
+    canônico `(mode, forces)` que o protocolo HID aceita.
+
+    - `mode`: valor do enum `pydualsense.TriggerModes` (0, 1, 2, 5, 6, 33, 34, 37, 38, 252).
+    - `forces`: 7 bytes (0-255) na ordem dos offsets HID 11/12..17/20 (USB)
+      ou 12/13..18/21 (BT). Posições não usadas pelo modo ficam em 0.
+    """
+
+    mode: int
+    forces: tuple[int, int, int, int, int, int, int] = (0, 0, 0, 0, 0, 0, 0)
+
+    def __post_init__(self) -> None:
+        if not (0 <= self.mode <= 255):
+            raise ValueError(f"mode fora de byte: {self.mode}")
+        if len(self.forces) != 7:
+            raise ValueError(f"forces precisa ter 7 elementos, recebeu {len(self.forces)}")
+        for i, b in enumerate(self.forces):
+            if not (0 <= b <= 255):
+                raise ValueError(f"forces[{i}] fora de byte: {b}")
+
+
+@dataclass(frozen=True)
+class ControllerState:
+    """Snapshot imutável do controle num instante.
+
+    Campos mínimos em W1.1; botões, sticks e touchpad entram em W1.2.
+    """
+
+    battery_pct: int
+    l2_raw: int
+    r2_raw: int
+    connected: bool
+    transport: Transport
+    raw_buttons: int = 0
+    raw_lx: int = 128
+    raw_ly: int = 128
+    raw_rx: int = 128
+    raw_ry: int = 128
+
+    def __post_init__(self) -> None:
+        if not (0 <= self.battery_pct <= 100):
+            raise ValueError(f"battery_pct fora de 0..100: {self.battery_pct}")
+        for name in ("l2_raw", "r2_raw", "raw_lx", "raw_ly", "raw_rx", "raw_ry"):
+            v = getattr(self, name)
+            if not (0 <= v <= 255):
+                raise ValueError(f"{name} fora de byte: {v}")
+
+
+class IController(ABC):
+    """Interface síncrona para um controle DualSense.
+
+    Implementações conhecidas:
+      - `hefesto.core.backend_pydualsense.PyDualSenseController` (hardware real).
+      - `tests.fixtures.fake_controller.FakeController` (replay de capture
+        ou comportamento determinístico para testes).
+    """
+
+    @abstractmethod
+    def connect(self) -> None: ...
+
+    @abstractmethod
+    def disconnect(self) -> None: ...
+
+    @abstractmethod
+    def is_connected(self) -> bool: ...
+
+    @abstractmethod
+    def read_state(self) -> ControllerState: ...
+
+    @abstractmethod
+    def set_trigger(self, side: Side, effect: TriggerEffect) -> None: ...
+
+    @abstractmethod
+    def set_led(self, color: tuple[int, int, int]) -> None: ...
+
+    @abstractmethod
+    def set_rumble(self, weak: int, strong: int) -> None: ...
+
+    @abstractmethod
+    def get_battery(self) -> int: ...
+
+    @abstractmethod
+    def get_transport(self) -> Transport: ...
+
+
+__all__ = [
+    "ControllerState",
+    "IController",
+    "Side",
+    "Transport",
+    "TriggerEffect",
+]

--- a/tests/fixtures/fake_controller.py
+++ b/tests/fixtures/fake_controller.py
@@ -1,0 +1,111 @@
+"""Backend fake para testes sem hardware.
+
+Implementa `IController` com comportamento determinístico:
+- Inicia desconectado; `connect()` marca conectado e carrega um snapshot.
+- `read_state()` avança entre snapshots pré-definidos (ou um padrão único).
+- `set_trigger/set_led/set_rumble` gravam em listas internas pra inspeção.
+
+Replay de captures binários (V2-13, V3-8) fica no mesmo módulo — quando o
+formato `.bin` for definido em W1.3, a classe ganha `from_capture(path)`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from hefesto.core.controller import (
+    ControllerState,
+    IController,
+    Side,
+    Transport,
+    TriggerEffect,
+)
+
+
+@dataclass
+class FakeControllerCommand:
+    """Registro de comando emitido — usado por testes pra asserts."""
+
+    kind: str
+    payload: object
+
+
+class FakeController(IController):
+    """Controle fake para testes unit e integration.
+
+    Parâmetros:
+      transport: "usb" ou "bt".
+      states: sequência de `ControllerState` retornados em cada `read_state`.
+        Após esgotar, repete o último indefinidamente.
+    """
+
+    DEFAULT_STATE: ClassVar[ControllerState] = ControllerState(
+        battery_pct=75,
+        l2_raw=0,
+        r2_raw=0,
+        connected=False,
+        transport="usb",
+    )
+
+    def __init__(
+        self,
+        transport: Transport = "usb",
+        states: list[ControllerState] | None = None,
+    ) -> None:
+        self._transport: Transport = transport
+        self._states: list[ControllerState] = states or []
+        self._idx: int = 0
+        self._connected: bool = False
+        self.commands: list[FakeControllerCommand] = []
+
+    def connect(self) -> None:
+        self._connected = True
+        if not self._states:
+            self._states = [
+                ControllerState(
+                    battery_pct=75,
+                    l2_raw=0,
+                    r2_raw=0,
+                    connected=True,
+                    transport=self._transport,
+                )
+            ]
+        self.commands.append(FakeControllerCommand("connect", None))
+
+    def disconnect(self) -> None:
+        self._connected = False
+        self.commands.append(FakeControllerCommand("disconnect", None))
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def read_state(self) -> ControllerState:
+        if not self._connected:
+            raise RuntimeError("FakeController nao conectado — chamar connect() antes")
+        if self._idx < len(self._states):
+            state = self._states[self._idx]
+            self._idx += 1
+        else:
+            state = self._states[-1]
+        return state
+
+    def set_trigger(self, side: Side, effect: TriggerEffect) -> None:
+        self.commands.append(FakeControllerCommand("set_trigger", (side, effect)))
+
+    def set_led(self, color: tuple[int, int, int]) -> None:
+        self.commands.append(FakeControllerCommand("set_led", color))
+
+    def set_rumble(self, weak: int, strong: int) -> None:
+        self.commands.append(FakeControllerCommand("set_rumble", (weak, strong)))
+
+    def get_battery(self) -> int:
+        if not self._states:
+            return FakeController.DEFAULT_STATE.battery_pct
+        idx = min(self._idx, len(self._states) - 1)
+        return self._states[idx].battery_pct
+
+    def get_transport(self) -> Transport:
+        return self._transport
+
+
+__all__ = ["FakeController", "FakeControllerCommand"]

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -1,0 +1,143 @@
+"""Testes da interface `IController` e das validações dos dataclasses."""
+from __future__ import annotations
+
+import pytest
+
+from hefesto.core.controller import (
+    ControllerState,
+    IController,
+    TriggerEffect,
+)
+from tests.fixtures.fake_controller import FakeController
+
+
+class TestTriggerEffect:
+    def test_defaults_are_zero(self) -> None:
+        eff = TriggerEffect(mode=0)
+        assert eff.forces == (0, 0, 0, 0, 0, 0, 0)
+
+    def test_mode_out_of_byte_raises(self) -> None:
+        with pytest.raises(ValueError, match="mode fora de byte"):
+            TriggerEffect(mode=300)
+
+    def test_forces_wrong_arity_raises(self) -> None:
+        with pytest.raises(ValueError, match="forces precisa ter 7"):
+            TriggerEffect(mode=1, forces=(0, 0, 0))  # type: ignore[arg-type]
+
+    def test_force_byte_out_of_range_raises(self) -> None:
+        with pytest.raises(ValueError, match="forces\\[3\\] fora de byte"):
+            TriggerEffect(mode=1, forces=(0, 0, 0, 256, 0, 0, 0))
+
+
+class TestControllerState:
+    def test_basic_snapshot(self) -> None:
+        s = ControllerState(
+            battery_pct=50, l2_raw=0, r2_raw=0, connected=True, transport="usb"
+        )
+        assert s.battery_pct == 50
+        assert s.raw_lx == 128
+
+    def test_battery_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match="battery_pct"):
+            ControllerState(
+                battery_pct=150, l2_raw=0, r2_raw=0, connected=True, transport="usb"
+            )
+
+    def test_raw_byte_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match="l2_raw"):
+            ControllerState(
+                battery_pct=50, l2_raw=999, r2_raw=0, connected=True, transport="usb"
+            )
+
+
+class TestFakeController:
+    def test_implements_interface(self) -> None:
+        fc = FakeController()
+        assert isinstance(fc, IController)
+
+    def test_read_before_connect_fails(self) -> None:
+        fc = FakeController()
+        with pytest.raises(RuntimeError, match="nao conectado"):
+            fc.read_state()
+
+    def test_default_state_after_connect(self) -> None:
+        fc = FakeController(transport="usb")
+        fc.connect()
+        state = fc.read_state()
+        assert state.connected is True
+        assert state.transport == "usb"
+        assert state.battery_pct == 75
+
+    def test_replay_sequence(self) -> None:
+        states = [
+            ControllerState(
+                battery_pct=80, l2_raw=0, r2_raw=0, connected=True, transport="bt"
+            ),
+            ControllerState(
+                battery_pct=79, l2_raw=50, r2_raw=100, connected=True, transport="bt"
+            ),
+            ControllerState(
+                battery_pct=79, l2_raw=200, r2_raw=255, connected=True, transport="bt"
+            ),
+        ]
+        fc = FakeController(transport="bt", states=states)
+        fc.connect()
+        assert fc.read_state() == states[0]
+        assert fc.read_state() == states[1]
+        assert fc.read_state() == states[2]
+        assert fc.read_state() == states[2]  # últimos repetem
+
+    def test_transport_bt_propaga(self) -> None:
+        fc = FakeController(transport="bt")
+        fc.connect()
+        assert fc.get_transport() == "bt"
+        assert fc.read_state().transport == "bt"
+
+    def test_commands_gravados(self) -> None:
+        fc = FakeController()
+        fc.connect()
+        fc.set_trigger("right", TriggerEffect(mode=1, forces=(5, 200, 0, 0, 0, 0, 0)))
+        fc.set_led((255, 0, 128))
+        fc.set_rumble(weak=100, strong=200)
+        kinds = [c.kind for c in fc.commands]
+        assert kinds == ["connect", "set_trigger", "set_led", "set_rumble"]
+
+    def test_disconnect_marks_disconnected(self) -> None:
+        fc = FakeController()
+        fc.connect()
+        assert fc.is_connected() is True
+        fc.disconnect()
+        assert fc.is_connected() is False
+
+
+class TestPyDualSenseController:
+    """Smoke test do backend real via mock do pydualsense.
+
+    Não conecta a hardware físico. Valida que a classe respeita
+    `IController`, inicializa sem quebrar e aceita comandos.
+    """
+
+    def test_class_implements_interface(self) -> None:
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+        inst = PyDualSenseController()
+        assert isinstance(inst, IController)
+
+    def test_require_sem_connect_falha(self) -> None:
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+        inst = PyDualSenseController()
+        with pytest.raises(RuntimeError, match="nao inicializado"):
+            inst.read_state()
+
+    def test_coerce_mode_conhecido(self) -> None:
+        from pydualsense.enums import TriggerModes
+
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+
+        coerced = PyDualSenseController._coerce_mode(TriggerModes.Rigid.value)
+        assert coerced == TriggerModes.Rigid
+
+    def test_coerce_mode_invalido_mantem_raw(self) -> None:
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+
+        coerced = PyDualSenseController._coerce_mode(0x99)
+        assert coerced == 0x99


### PR DESCRIPTION
## Resumo
Implementa a base HID do daemon: interface sincrona, backend real sobre pydualsense e fake para testes.

## Escopo
- `IController` ABC com 9 metodos (connect/disconnect/is_connected/read_state/set_trigger/set_led/set_rumble/get_battery/get_transport).
- `ControllerState` dataclass imutavel com `transport: Literal["usb", "bt"]` (V2-7) + validacao de ranges.
- `TriggerEffect` dataclass validando `mode` e `forces` (7 bytes).
- `PyDualSenseController` adapter thin sobre pydualsense 0.7.5.
- `FakeController` deterministico para testes (registra comandos, aceita replay).
- Reescrita de `docs/protocol/trigger-modes.md` em dois niveis (HID + presets) fechando os 4 pontos pendentes da auditoria (Machine arity, PulseB order, frequency saturation, CustomTriggerValue via --raw).

## Runtime checks
- `./scripts/check_anonymity.sh`: OK
- `ruff check src/ tests/`: pass
- `mypy src/hefesto` (strict): pass (14 arquivos)
- `pytest tests/unit -v`: **37 passed**

## Referencias
- V2 Patch 2 (ControllerState + IController).
- V2-7 (transport).
- V3 fecha os 4 pontos da tabela de trigger modes.
- ADR-001, ADR-008.

Closes #1