### PR TITLE
W1.2: Event bus + state store thread-safe

### DIFF
--- a/src/hefesto/core/events.py
+++ b/src/hefesto/core/events.py
@@ -1,0 +1,132 @@
+"""Event bus async baseado em asyncio.Queue por subscriber.
+
+Modelo pubsub simples:
+  - `publish(topic, payload)` entrega para todas as filas registradas no tópico.
+  - `subscribe(topic)` devolve uma `asyncio.Queue` dedicada e não-bloqueante.
+  - Publisher nunca bloqueia: se a fila está cheia, o evento mais antigo
+    é descartado (política `drop_oldest`) e emite log.warning uma vez por
+    subscriber congestionado no ciclo.
+
+Tópicos canônicos do domínio Hefesto (constantes em `EventTopic`):
+  - `state.update`       — novo `ControllerState` completo.
+  - `button.down` / `button.up` — mudanças de botão.
+  - `battery.change`     — bateria mudou segundo debounce (ver ADR-008).
+  - `controller.connected` / `controller.disconnected`.
+  - `trigger.set`        — trigger efetivamente aplicado.
+  - `led.set`            — led efetivamente aplicado.
+
+Thread-safety: `publish` pode ser chamado de dentro de um executor
+(thread diferente do loop). A entrega usa `loop.call_soon_threadsafe`
+para enfileirar sem races. `subscribe` deve ser chamado do loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_QUEUE_MAXSIZE = 256
+
+
+class EventTopic:
+    STATE_UPDATE = "state.update"
+    BUTTON_DOWN = "button.down"
+    BUTTON_UP = "button.up"
+    BATTERY_CHANGE = "battery.change"
+    CONTROLLER_CONNECTED = "controller.connected"
+    CONTROLLER_DISCONNECTED = "controller.disconnected"
+    TRIGGER_SET = "trigger.set"
+    LED_SET = "led.set"
+
+
+@dataclass
+class _Subscriber:
+    queue: asyncio.Queue[Any]
+    overflow_logged: bool = False
+
+
+@dataclass
+class EventBus:
+    """Barramento pubsub assíncrono e thread-safe no lado do publisher."""
+
+    queue_maxsize: int = DEFAULT_QUEUE_MAXSIZE
+    _subs: dict[str, list[_Subscriber]] = field(default_factory=dict)
+    _loop: asyncio.AbstractEventLoop | None = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Marca qual loop o bus serve. Chamado uma vez no start do daemon."""
+        self._loop = loop
+
+    def subscribe(self, topic: str) -> asyncio.Queue[Any]:
+        """Cria uma fila dedicada para o subscriber. Sempre chamada do loop."""
+        queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=self.queue_maxsize)
+        sub = _Subscriber(queue=queue)
+        self._subs.setdefault(topic, []).append(sub)
+        return queue
+
+    def unsubscribe(self, topic: str, queue: asyncio.Queue[Any]) -> None:
+        subs = self._subs.get(topic, [])
+        self._subs[topic] = [s for s in subs if s.queue is not queue]
+
+    def publish(self, topic: str, payload: Any) -> None:
+        """Publica um evento. Seguro para chamar de threads não-loop.
+
+        Se chamado do loop do daemon, entrega direto. Se chamado de outra
+        thread, usa `call_soon_threadsafe` para marshal. Filas cheias
+        descartam o evento mais antigo e logam warning uma vez.
+        """
+        subs = list(self._subs.get(topic, ()))
+        if not subs:
+            return
+
+        loop = self._loop
+        if loop is None:
+            for sub in subs:
+                self._deliver(sub, topic, payload)
+            return
+
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+
+        if running is loop:
+            for sub in subs:
+                self._deliver(sub, topic, payload)
+        else:
+            for sub in subs:
+                loop.call_soon_threadsafe(self._deliver, sub, topic, payload)
+
+    def _deliver(self, sub: _Subscriber, topic: str, payload: Any) -> None:
+        try:
+            sub.queue.put_nowait(payload)
+            sub.overflow_logged = False
+            return
+        except asyncio.QueueFull:
+            pass
+
+        with contextlib.suppress(asyncio.QueueEmpty):
+            sub.queue.get_nowait()
+            with contextlib.suppress(asyncio.QueueFull):
+                sub.queue.put_nowait(payload)
+
+        if not sub.overflow_logged:
+            logger.warning(
+                "fila de subscriber cheia em %s — evento antigo descartado",
+                topic,
+            )
+            sub.overflow_logged = True
+
+    def topics(self) -> Iterable[str]:
+        return tuple(self._subs.keys())
+
+    def subscriber_count(self, topic: str) -> int:
+        return len(self._subs.get(topic, []))
+
+
+__all__ = ["DEFAULT_QUEUE_MAXSIZE", "EventBus", "EventTopic"]

--- a/src/hefesto/daemon/state_store.py
+++ b/src/hefesto/daemon/state_store.py
@@ -1,0 +1,101 @@
+"""Estado atual do daemon, compartilhado entre threads (poll) e loop (consumers).
+
+`StateStore` guarda uma snapshot consistente do controle + perfil ativo +
+contadores runtime. Todas as leituras retornam cópias imutáveis
+(`ControllerState` já é `frozen=True`, dicionários são copiados rasos);
+escrita usa `threading.RLock` para evitar write-tearing entre poll
+(executor) e reload (CLI/IPC).
+
+Consumo típico:
+    store = StateStore()
+    store.update_controller_state(state)       # chamado do executor
+    snap = store.snapshot()                    # chamado do loop ou CLI
+    active = store.active_profile              # propriedade read-only
+"""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+from hefesto.core.controller import ControllerState
+
+
+@dataclass(frozen=True)
+class StoreSnapshot:
+    """Snapshot consistente do estado do daemon num instante."""
+
+    controller: ControllerState | None
+    active_profile: str | None
+    last_battery_pct: int | None
+    counters: dict[str, int]
+
+
+class StateStore:
+    """Repositório thread-safe do estado do daemon.
+
+    Escritas usam `RLock`; leituras retornam cópias. RLock (reentrante)
+    evita deadlock se um callback dentro de `with self._lock` chamar
+    outro método que também adquire o lock (ex: logging).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._controller_state: ControllerState | None = None
+        self._active_profile: str | None = None
+        self._last_battery_pct: int | None = None
+        self._counters: dict[str, int] = {}
+
+    # --- escritas ------------------------------------------------------
+
+    def update_controller_state(self, state: ControllerState) -> None:
+        with self._lock:
+            self._controller_state = state
+            if state.battery_pct != self._last_battery_pct:
+                self._last_battery_pct = state.battery_pct
+
+    def set_active_profile(self, name: str | None) -> None:
+        with self._lock:
+            self._active_profile = name
+
+    def bump(self, counter: str, delta: int = 1) -> int:
+        with self._lock:
+            value = self._counters.get(counter, 0) + delta
+            self._counters[counter] = value
+            return value
+
+    def reset_counters(self) -> None:
+        with self._lock:
+            self._counters.clear()
+
+    # --- leituras ------------------------------------------------------
+
+    @property
+    def controller_state(self) -> ControllerState | None:
+        with self._lock:
+            return self._controller_state
+
+    @property
+    def active_profile(self) -> str | None:
+        with self._lock:
+            return self._active_profile
+
+    @property
+    def last_battery_pct(self) -> int | None:
+        with self._lock:
+            return self._last_battery_pct
+
+    def counter(self, name: str) -> int:
+        with self._lock:
+            return self._counters.get(name, 0)
+
+    def snapshot(self) -> StoreSnapshot:
+        with self._lock:
+            return StoreSnapshot(
+                controller=self._controller_state,
+                active_profile=self._active_profile,
+                last_battery_pct=self._last_battery_pct,
+                counters=dict(self._counters),
+            )
+
+
+__all__ = ["StateStore", "StoreSnapshot"]

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,0 +1,116 @@
+"""Testes do EventBus async."""
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from hefesto.core.events import EventBus, EventTopic
+
+
+@pytest.mark.asyncio
+async def test_subscribe_entrega_publicacao():
+    bus = EventBus()
+    queue = bus.subscribe(EventTopic.STATE_UPDATE)
+    bus.publish(EventTopic.STATE_UPDATE, {"battery": 80})
+    payload = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert payload == {"battery": 80}
+
+
+@pytest.mark.asyncio
+async def test_multiplos_subscribers_recebem_copia_logica():
+    bus = EventBus()
+    q1 = bus.subscribe("t")
+    q2 = bus.subscribe("t")
+    bus.publish("t", "hello")
+    assert await asyncio.wait_for(q1.get(), timeout=1.0) == "hello"
+    assert await asyncio.wait_for(q2.get(), timeout=1.0) == "hello"
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_para_de_receber():
+    bus = EventBus()
+    queue = bus.subscribe("t")
+    bus.unsubscribe("t", queue)
+    bus.publish("t", "perdido")
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(queue.get(), timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_topico_sem_subscriber_e_noop():
+    bus = EventBus()
+    bus.publish("inexistente", "x")
+
+
+@pytest.mark.asyncio
+async def test_fila_cheia_drop_oldest():
+    bus = EventBus(queue_maxsize=3)
+    queue = bus.subscribe("t")
+    for i in range(5):
+        bus.publish("t", i)
+    # Esperado: fila com os 3 mais recentes — 2, 3, 4
+    received = []
+    while not queue.empty():
+        received.append(await queue.get())
+    assert received == [2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_publish_cross_thread_via_loop():
+    bus = EventBus()
+    loop = asyncio.get_running_loop()
+    bus.bind_loop(loop)
+    queue = bus.subscribe(EventTopic.BATTERY_CHANGE)
+
+    def produtor():
+        bus.publish(EventTopic.BATTERY_CHANGE, 42)
+
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        await loop.run_in_executor(ex, produtor)
+
+    payload = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert payload == 42
+
+
+@pytest.mark.asyncio
+async def test_subscriber_count():
+    bus = EventBus()
+    assert bus.subscriber_count("t") == 0
+    q1 = bus.subscribe("t")
+    q2 = bus.subscribe("t")
+    assert bus.subscriber_count("t") == 2
+    bus.unsubscribe("t", q1)
+    assert bus.subscriber_count("t") == 1
+    bus.unsubscribe("t", q2)
+    assert bus.subscriber_count("t") == 0
+
+
+@pytest.mark.asyncio
+async def test_concorrencia_publishers_multiplas_threads():
+    bus = EventBus(queue_maxsize=10000)
+    loop = asyncio.get_running_loop()
+    bus.bind_loop(loop)
+    queue = bus.subscribe("x")
+
+    n_threads = 4
+    n_msgs = 50
+
+    def produtor(offset: int):
+        for i in range(n_msgs):
+            bus.publish("x", offset * 1000 + i)
+
+    with ThreadPoolExecutor(max_workers=n_threads) as ex:
+        await asyncio.gather(
+            *(loop.run_in_executor(ex, produtor, k) for k in range(n_threads))
+        )
+
+    # Drena tudo
+    received = []
+    while True:
+        try:
+            received.append(await asyncio.wait_for(queue.get(), timeout=0.1))
+        except asyncio.TimeoutError:
+            break
+    assert len(received) == n_threads * n_msgs

--- a/tests/unit/test_state_store.py
+++ b/tests/unit/test_state_store.py
@@ -1,0 +1,132 @@
+"""Testes do StateStore thread-safe."""
+from __future__ import annotations
+
+import threading
+
+from hefesto.core.controller import ControllerState
+from hefesto.daemon.state_store import StateStore
+
+
+def _state(battery: int = 75) -> ControllerState:
+    return ControllerState(
+        battery_pct=battery,
+        l2_raw=0,
+        r2_raw=0,
+        connected=True,
+        transport="usb",
+    )
+
+
+def test_inicial_vazio():
+    s = StateStore()
+    assert s.controller_state is None
+    assert s.active_profile is None
+    assert s.last_battery_pct is None
+    assert s.counter("irrelevante") == 0
+
+
+def test_update_controller_state():
+    s = StateStore()
+    st = _state(80)
+    s.update_controller_state(st)
+    assert s.controller_state == st
+    assert s.last_battery_pct == 80
+
+
+def test_last_battery_tracking_atualiza_apenas_no_delta():
+    s = StateStore()
+    s.update_controller_state(_state(80))
+    s.update_controller_state(_state(80))
+    s.update_controller_state(_state(79))
+    assert s.last_battery_pct == 79
+
+
+def test_active_profile():
+    s = StateStore()
+    s.set_active_profile("shooter")
+    assert s.active_profile == "shooter"
+    s.set_active_profile(None)
+    assert s.active_profile is None
+
+
+def test_counters_bump_e_reset():
+    s = StateStore()
+    assert s.bump("udp.received") == 1
+    assert s.bump("udp.received") == 2
+    assert s.bump("udp.received", delta=5) == 7
+    assert s.counter("udp.received") == 7
+    s.reset_counters()
+    assert s.counter("udp.received") == 0
+
+
+def test_snapshot_e_imutavel_no_lado_consumidor():
+    s = StateStore()
+    s.update_controller_state(_state(60))
+    s.set_active_profile("driving")
+    s.bump("trigger.set", delta=3)
+
+    snap = s.snapshot()
+    assert snap.controller == _state(60)
+    assert snap.active_profile == "driving"
+    assert snap.counters == {"trigger.set": 3}
+
+    # Mutações posteriores não afetam snapshot já emitido
+    s.bump("trigger.set")
+    s.set_active_profile("bow")
+    assert snap.counters == {"trigger.set": 3}
+    assert snap.active_profile == "driving"
+
+
+def test_concorrencia_bump_sob_lock():
+    s = StateStore()
+    n_threads = 8
+    n_bumps = 500
+
+    def worker():
+        for _ in range(n_bumps):
+            s.bump("k")
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert s.counter("k") == n_threads * n_bumps
+
+
+def test_concorrencia_escrita_leitura():
+    s = StateStore()
+    writer_done = threading.Event()
+    erros: list[Exception] = []
+
+    def writer():
+        try:
+            for pct in range(100, -1, -1):
+                s.update_controller_state(_state(pct))
+        except Exception as exc:
+            erros.append(exc)
+        finally:
+            writer_done.set()
+
+    def reader():
+        try:
+            for _ in range(500):
+                snap = s.snapshot()
+                _ = snap.controller
+                _ = snap.counters
+        except Exception as exc:
+            erros.append(exc)
+
+    tw = threading.Thread(target=writer)
+    trs = [threading.Thread(target=reader) for _ in range(3)]
+
+    tw.start()
+    for t in trs:
+        t.start()
+    tw.join()
+    for t in trs:
+        t.join()
+
+    assert erros == []
+    assert s.last_battery_pct == 0


### PR DESCRIPTION
## Resumo
Base de coordenacao entre threads: EventBus async e StateStore com lock.

## Escopo
- `EventBus` com asyncio.Queue por subscriber, politica drop-oldest, publish cross-thread via `call_soon_threadsafe`. Topicos canonicos em `EventTopic`.
- `StateStore` com `RLock`, guarda `ControllerState` atual + perfil ativo + counters. `snapshot()` retorna `StoreSnapshot` frozen.
- 16 testes novos: pubsub, overflow, cross-thread, concorrencia writer+readers.

## Runtime checks
- `scripts/check_anonymity.sh`: OK
- `ruff check`: pass
- `mypy` (strict, 16 arquivos): pass
- `pytest tests/unit -v`: **53 passed**

Closes #2