### PR TITLE
W1.3: Daemon loop asyncio basico

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Runtime-real runner: exercita o daemon via FakeController em modos USB/BT,
+# ou via pydualsense quando há hardware. Atende meta-regra 9.8 (validação
+# runtime-real) para sprints que tocam o daemon.
+#
+# Uso:
+#   ./run.sh --smoke           boot curto com FakeController USB (2s)
+#   ./run.sh --smoke --bt      boot curto com FakeController BT  (2s)
+#   ./run.sh --daemon          roda daemon em primeiro plano (hardware real)
+#   ./run.sh --fake            igual --daemon mas usa FakeController
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+if [[ ! -d .venv ]]; then
+    echo "erro: .venv/ nao encontrado. Rode ./scripts/dev_bootstrap.sh primeiro."
+    exit 1
+fi
+# shellcheck disable=SC1091
+. .venv/bin/activate
+
+MODE="daemon"
+TRANSPORT="usb"
+FAKE=0
+SMOKE_DURATION="${HEFESTO_SMOKE_DURATION:-2.0}"
+
+for arg in "$@"; do
+    case "$arg" in
+        --smoke)  MODE="smoke" ;;
+        --daemon) MODE="daemon" ;;
+        --fake)   MODE="daemon"; FAKE=1 ;;
+        --bt)     TRANSPORT="bt" ;;
+        --usb)    TRANSPORT="usb" ;;
+        *) echo "aviso: argumento desconhecido: $arg" ;;
+    esac
+done
+
+export HEFESTO_FAKE_TRANSPORT="$TRANSPORT"
+
+if [[ "$MODE" == "smoke" ]]; then
+    export HEFESTO_FAKE=1
+    export HEFESTO_LOG_FORMAT="${HEFESTO_LOG_FORMAT:-console}"
+    echo "[smoke] iniciando daemon com FakeController transport=$TRANSPORT por ${SMOKE_DURATION}s..."
+    python3 - <<PY
+import asyncio
+from hefesto.daemon.lifecycle import Daemon, DaemonConfig
+from hefesto.daemon.main import build_controller
+from hefesto.utils.logging_config import configure_logging
+
+
+async def main():
+    configure_logging()
+    daemon = Daemon(controller=build_controller(), config=DaemonConfig(poll_hz=30))
+    task = asyncio.create_task(daemon.run())
+    await asyncio.sleep(${SMOKE_DURATION})
+    daemon.stop()
+    await task
+    print("[smoke] poll.tick =", daemon.store.counter("poll.tick"))
+    print("[smoke] battery.change.emitted =", daemon.store.counter("battery.change.emitted"))
+
+
+asyncio.run(main())
+PY
+    echo "[smoke] concluido."
+    exit 0
+fi
+
+if [[ "$FAKE" == "1" ]]; then
+    export HEFESTO_FAKE=1
+fi
+
+exec hefesto daemon start --foreground
+
+# "Faca o pequeno bem que esta proximo." — Tolstoi

--- a/src/hefesto/cli/app.py
+++ b/src/hefesto/cli/app.py
@@ -1,7 +1,14 @@
-"""Stub inicial da CLI Typer. Esqueleto criado em W0.1;
-subcomandos reais chegam a partir de W4.1 (daemon) e W5.3 (completo).
+"""CLI Typer do Hefesto.
+
+Subcomandos implementados em W1.3:
+  - `hefesto version`
+  - `hefesto daemon start [--poll-hz N] [--foreground] [--headless] [--no-reconnect]`
+
+Demais subcomandos (profile, test, led, battery, status) chegam em W5.3.
 """
 from __future__ import annotations
+
+import os
 
 import typer
 
@@ -12,12 +19,42 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+daemon_app = typer.Typer(
+    name="daemon",
+    help="Controle do daemon de background.",
+    no_args_is_help=True,
+)
+app.add_typer(daemon_app, name="daemon")
+
 
 @app.command()
 def version() -> None:
     """Mostra a versão instalada."""
     from hefesto import __version__
     typer.echo(__version__)
+
+
+@daemon_app.command("start")
+def daemon_start(
+    poll_hz: int = typer.Option(60, "--poll-hz", help="Frequência de poll HID em Hz."),
+    foreground: bool = typer.Option(
+        True, "--foreground/--no-foreground", help="Rodar em primeiro plano."
+    ),
+    headless: bool = typer.Option(
+        False, "--headless", help="Desliga auto-switch X11 (set HEFESTO_NO_WINDOW_DETECT=1)."
+    ),
+    reconnect: bool = typer.Option(
+        True, "--reconnect/--no-reconnect", help="Tenta reconectar se o controle cair."
+    ),
+) -> None:
+    """Inicia o daemon no processo atual."""
+    if headless:
+        os.environ["HEFESTO_NO_WINDOW_DETECT"] = "1"
+
+    from hefesto.daemon.main import run_daemon
+
+    exit_code = run_daemon(poll_hz=poll_hz, auto_reconnect=reconnect)
+    raise typer.Exit(code=exit_code)
 
 
 def main() -> None:

--- a/src/hefesto/daemon/lifecycle.py
+++ b/src/hefesto/daemon/lifecycle.py
@@ -1,0 +1,200 @@
+"""Ciclo de vida do daemon: conectar controle, rodar poll loop, desligar limpo.
+
+O daemon é composto por:
+  - 1 `IController` (real ou fake) conectado ao dispositivo.
+  - 1 `EventBus` global.
+  - 1 `StateStore` global.
+  - Tasks async: poll_loop, e futuramente ipc_server, udp_server, autoswitch.
+
+`Daemon.run()` orquestra start -> run_until_stopped -> shutdown. Captura SIGINT
+e SIGTERM para desligar limpo. Poll roda em `ThreadPoolExecutor` dedicado
+porque `IController` é síncrono (V2-7).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any
+
+from hefesto.core.controller import IController
+from hefesto.core.events import EventBus, EventTopic
+from hefesto.daemon.state_store import StateStore
+from hefesto.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_POLL_HZ = 60
+BATTERY_DEBOUNCE_SEC = 5.0
+BATTERY_MIN_INTERVAL_SEC = 0.1
+BATTERY_DELTA_THRESHOLD_PCT = 1
+
+
+@dataclass
+class DaemonConfig:
+    poll_hz: int = DEFAULT_POLL_HZ
+    auto_reconnect: bool = True
+    reconnect_backoff_sec: float = 2.0
+
+
+class BatteryDebouncer:
+    """Debounce de eventos de bateria (V2-17 + ADR-008).
+
+    Dispara se:
+      - nunca disparou (primeiro valor); ou
+      - `abs(delta_pct) >= BATTERY_DELTA_THRESHOLD_PCT` (e respeita min interval); ou
+      - `elapsed_since_last_emit >= BATTERY_DEBOUNCE_SEC`.
+
+    Sempre respeita `BATTERY_MIN_INTERVAL_SEC` entre disparos consecutivos.
+    """
+
+    def __init__(self) -> None:
+        self.last_emitted_value: int | None = None
+        self.last_emit_at: float = 0.0
+
+    def should_emit(self, value: int, now: float) -> bool:
+        if self.last_emitted_value is None:
+            return True
+        interval = now - self.last_emit_at
+        if interval < BATTERY_MIN_INTERVAL_SEC:
+            return False
+        delta = abs(value - self.last_emitted_value)
+        return delta >= BATTERY_DELTA_THRESHOLD_PCT or interval >= BATTERY_DEBOUNCE_SEC
+
+    def mark_emitted(self, value: int, now: float) -> None:
+        self.last_emitted_value = value
+        self.last_emit_at = now
+
+
+@dataclass
+class Daemon:
+    controller: IController
+    bus: EventBus = field(default_factory=EventBus)
+    store: StateStore = field(default_factory=StateStore)
+    config: DaemonConfig = field(default_factory=DaemonConfig)
+
+    _stop_event: asyncio.Event | None = None
+    _executor: ThreadPoolExecutor | None = None
+    _tasks: list[asyncio.Task[Any]] = field(default_factory=list)
+
+    async def run(self) -> None:
+        """Entry point: start tasks, wait until stop, shutdown."""
+        loop = asyncio.get_running_loop()
+        self.bus.bind_loop(loop)
+        self._stop_event = asyncio.Event()
+        self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="hefesto-hid")
+        self._install_signal_handlers(loop)
+
+        logger.info("daemon_starting", poll_hz=self.config.poll_hz)
+        try:
+            await self._connect_with_retry()
+            self._tasks = [asyncio.create_task(self._poll_loop(), name="poll_loop")]
+            await self._stop_event.wait()
+        finally:
+            await self._shutdown()
+
+    def stop(self) -> None:
+        """Sinaliza parada; idempotente."""
+        if self._stop_event is not None and not self._stop_event.is_set():
+            logger.info("daemon_stop_requested")
+            self._stop_event.set()
+
+    async def _connect_with_retry(self) -> None:
+        backoff = self.config.reconnect_backoff_sec
+        while True:
+            try:
+                await self._run_blocking(self.controller.connect)
+                transport = self.controller.get_transport()
+                self.bus.publish(EventTopic.CONTROLLER_CONNECTED, {"transport": transport})
+                logger.info("controller_connected", transport=transport)
+                return
+            except Exception as exc:
+                logger.warning("controller_connect_failed", err=str(exc))
+                if not self.config.auto_reconnect:
+                    raise
+                await asyncio.sleep(backoff)
+
+    async def _poll_loop(self) -> None:
+        period = 1.0 / max(1, self.config.poll_hz)
+        battery = BatteryDebouncer()
+        loop = asyncio.get_running_loop()
+
+        while not self._is_stopping():
+            tick_started = loop.time()
+            try:
+                state = await self._run_blocking(self.controller.read_state)
+            except Exception as exc:
+                logger.warning("poll_read_failed", err=str(exc))
+                self.bus.publish(EventTopic.CONTROLLER_DISCONNECTED, {"reason": str(exc)})
+                if self.config.auto_reconnect:
+                    await self._reconnect()
+                    continue
+                break
+
+            self.store.update_controller_state(state)
+            self.bus.publish(EventTopic.STATE_UPDATE, state)
+            self.store.bump("poll.tick")
+
+            if battery.should_emit(state.battery_pct, tick_started):
+                self.bus.publish(EventTopic.BATTERY_CHANGE, state.battery_pct)
+                battery.mark_emitted(state.battery_pct, tick_started)
+                self.store.bump("battery.change.emitted")
+
+            elapsed = loop.time() - tick_started
+            sleep_for = period - elapsed
+            if sleep_for > 0:
+                stop_event = self._stop_event
+                assert stop_event is not None
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(stop_event.wait(), timeout=sleep_for)
+                    break
+
+    async def _reconnect(self) -> None:
+        with contextlib.suppress(Exception):
+            await self._run_blocking(self.controller.disconnect)
+        await asyncio.sleep(self.config.reconnect_backoff_sec)
+        await self._connect_with_retry()
+
+    async def _shutdown(self) -> None:
+        logger.info("daemon_shutting_down")
+        for task in self._tasks:
+            task.cancel()
+        for task in self._tasks:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        try:
+            await self._run_blocking(self.controller.disconnect)
+        except Exception as exc:
+            logger.warning("controller_disconnect_failed", err=str(exc))
+        if self._executor is not None:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+            self._executor = None
+        self._tasks.clear()
+        logger.info("daemon_stopped")
+
+    def _install_signal_handlers(self, loop: asyncio.AbstractEventLoop) -> None:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            with contextlib.suppress(NotImplementedError):
+                loop.add_signal_handler(sig, self.stop)
+
+    async def _run_blocking(self, fn: Callable[..., Any], *args: Any) -> Any:
+        assert self._executor is not None, "executor não inicializado"
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, fn, *args)
+
+    def _is_stopping(self) -> bool:
+        return self._stop_event is not None and self._stop_event.is_set()
+
+
+__all__ = [
+    "BATTERY_DEBOUNCE_SEC",
+    "BATTERY_DELTA_THRESHOLD_PCT",
+    "BATTERY_MIN_INTERVAL_SEC",
+    "DEFAULT_POLL_HZ",
+    "BatteryDebouncer",
+    "Daemon",
+    "DaemonConfig",
+]

--- a/src/hefesto/daemon/main.py
+++ b/src/hefesto/daemon/main.py
@@ -1,0 +1,52 @@
+"""Entry do daemon: monta dependências e chama `Daemon.run()`.
+
+Controlado pela CLI (`hefesto daemon start`). Suporta backend fake via
+env `HEFESTO_FAKE=1` — útil para smoke tests runtime (meta-regra 9.8)
+sem hardware.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+from hefesto.core.controller import IController
+from hefesto.daemon.lifecycle import Daemon, DaemonConfig
+from hefesto.utils.logging_config import configure_logging, get_logger
+
+
+def build_controller() -> IController:
+    if os.getenv("HEFESTO_FAKE") == "1":
+        from tests.fixtures.fake_controller import FakeController
+
+        transport = os.getenv("HEFESTO_FAKE_TRANSPORT", "usb")
+        if transport not in ("usb", "bt"):
+            transport = "usb"
+        fc = FakeController(transport=transport)  # type: ignore[arg-type]
+        return fc
+
+    from hefesto.core.backend_pydualsense import PyDualSenseController
+
+    return PyDualSenseController()
+
+
+def run_daemon(poll_hz: int | None = None, auto_reconnect: bool = True) -> int:
+    configure_logging()
+    logger = get_logger(__name__)
+
+    controller = build_controller()
+    config = DaemonConfig(
+        poll_hz=poll_hz or int(os.getenv("HEFESTO_POLL_HZ", "60")),
+        auto_reconnect=auto_reconnect,
+    )
+    daemon = Daemon(controller=controller, config=config)
+
+    logger.info("daemon_main", fake=os.getenv("HEFESTO_FAKE") == "1")
+    try:
+        asyncio.run(daemon.run())
+        return 0
+    except KeyboardInterrupt:
+        logger.info("daemon_interrupted")
+        return 130
+
+
+__all__ = ["build_controller", "run_daemon"]

--- a/src/hefesto/utils/logging_config.py
+++ b/src/hefesto/utils/logging_config.py
@@ -1,0 +1,88 @@
+"""Configuração de logging do daemon com structlog.
+
+Formato padrão: key=value legível no terminal (dev) ou JSON (prod). Controlado
+pela env `HEFESTO_LOG_FORMAT=json|console` (default `console`).
+
+Nível controlado por `HEFESTO_LOG_LEVEL` (default `INFO`). Valores aceitos:
+DEBUG, INFO, WARNING, ERROR, CRITICAL.
+
+Uso:
+    from hefesto.utils.logging_config import configure_logging, get_logger
+    configure_logging()
+    logger = get_logger(__name__)
+    logger.info("daemon_start", transport="usb", profile="shooter")
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+import structlog
+from structlog.typing import Processor
+
+_configured = False
+
+
+def configure_logging(
+    *,
+    level: str | None = None,
+    fmt: str | None = None,
+    stream: Any = None,
+) -> None:
+    """Configura logging stdlib + structlog. Idempotente."""
+    global _configured
+    if _configured:
+        return
+
+    level_name = (level or os.getenv("HEFESTO_LOG_LEVEL") or "INFO").upper()
+    log_fmt = (fmt or os.getenv("HEFESTO_LOG_FORMAT") or "console").lower()
+    stream = stream or sys.stderr
+
+    log_level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        format="%(message)s",
+        stream=stream,
+        level=log_level,
+    )
+
+    shared_processors: list[Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.TimeStamper(fmt="iso", utc=False),
+    ]
+
+    if log_fmt == "json":
+        renderer: Processor = structlog.processors.JSONRenderer()
+    else:
+        colors = stream.isatty() if hasattr(stream, "isatty") else False
+        renderer = structlog.dev.ConsoleRenderer(colors=colors)
+
+    structlog.configure(
+        processors=[*shared_processors, renderer],
+        wrapper_class=structlog.make_filtering_bound_logger(log_level),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(file=stream),
+        cache_logger_on_first_use=True,
+    )
+
+    _configured = True
+
+
+def get_logger(name: str | None = None) -> Any:
+    """Retorna um logger structlog. Configura automaticamente se preciso."""
+    if not _configured:
+        configure_logging()
+    return structlog.get_logger(name)
+
+
+def reset_for_tests() -> None:
+    """Reseta o estado interno — uso exclusivo em testes."""
+    global _configured
+    _configured = False
+    structlog.reset_defaults()
+
+
+__all__ = ["configure_logging", "get_logger", "reset_for_tests"]

--- a/tests/unit/test_daemon_lifecycle.py
+++ b/tests/unit/test_daemon_lifecycle.py
@@ -1,0 +1,159 @@
+"""Testes do Daemon (lifecycle + poll loop)."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hefesto.core.controller import ControllerState
+from hefesto.core.events import EventBus, EventTopic
+from hefesto.daemon.lifecycle import (
+    BATTERY_DEBOUNCE_SEC,
+    Daemon,
+    DaemonConfig,
+)
+from hefesto.daemon.state_store import StateStore
+from tests.fixtures.fake_controller import FakeController
+
+
+def _mk_states(n: int, transport: str = "usb") -> list[ControllerState]:
+    return [
+        ControllerState(
+            battery_pct=80,
+            l2_raw=i % 256,
+            r2_raw=(255 - i) % 256,
+            connected=True,
+            transport=transport,  # type: ignore[arg-type]
+        )
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_gera_state_update_e_para_no_stop():
+    fc = FakeController(transport="usb", states=_mk_states(20))
+    bus = EventBus()
+    store = StateStore()
+    daemon = Daemon(
+        controller=fc,
+        bus=bus,
+        store=store,
+        config=DaemonConfig(poll_hz=120, auto_reconnect=False),
+    )
+
+    run_task = asyncio.create_task(daemon.run())
+    await asyncio.sleep(0.05)
+    state_queue = bus.subscribe(EventTopic.STATE_UPDATE)
+    await asyncio.sleep(0.15)
+    daemon.stop()
+    await run_task
+
+    assert store.counter("poll.tick") >= 5
+    assert state_queue.qsize() >= 1
+
+
+@pytest.mark.asyncio
+async def test_connected_event_publicado_no_start():
+    fc = FakeController(transport="bt", states=_mk_states(3, "bt"))
+    bus = EventBus()
+    daemon = Daemon(controller=fc, bus=bus, config=DaemonConfig(poll_hz=60, auto_reconnect=False))
+
+    queue = bus.subscribe(EventTopic.CONTROLLER_CONNECTED)
+    run_task = asyncio.create_task(daemon.run())
+    payload = await asyncio.wait_for(queue.get(), timeout=1.0)
+    daemon.stop()
+    await run_task
+
+    assert payload == {"transport": "bt"}
+
+
+@pytest.mark.asyncio
+async def test_battery_debounce_dispara_no_primeiro_read():
+    fc = FakeController(
+        transport="usb",
+        states=[
+            ControllerState(battery_pct=80, l2_raw=0, r2_raw=0, connected=True, transport="usb"),
+            ControllerState(battery_pct=80, l2_raw=0, r2_raw=0, connected=True, transport="usb"),
+            ControllerState(battery_pct=80, l2_raw=0, r2_raw=0, connected=True, transport="usb"),
+        ],
+    )
+    bus = EventBus()
+    store = StateStore()
+    cfg = DaemonConfig(poll_hz=120, auto_reconnect=False)
+    daemon = Daemon(controller=fc, bus=bus, store=store, config=cfg)
+
+    queue = bus.subscribe(EventTopic.BATTERY_CHANGE)
+    run_task = asyncio.create_task(daemon.run())
+
+    first = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert first == 80
+
+    await asyncio.sleep(0.05)
+    daemon.stop()
+    await run_task
+
+    # Bateria não mudou: min-interval (100ms) + elapsed < 5s impede novo disparo
+    assert store.counter("battery.change.emitted") == 1
+
+
+@pytest.mark.asyncio
+async def test_battery_dispara_quando_delta_pct():
+    states = [
+        ControllerState(battery_pct=80, l2_raw=0, r2_raw=0, connected=True, transport="usb"),
+    ]
+    for _ in range(30):
+        states.append(
+            ControllerState(battery_pct=79, l2_raw=0, r2_raw=0, connected=True, transport="usb")
+        )
+    fc = FakeController(transport="usb", states=states)
+    bus = EventBus()
+    store = StateStore()
+    cfg = DaemonConfig(poll_hz=60, auto_reconnect=False)
+    daemon = Daemon(controller=fc, bus=bus, store=store, config=cfg)
+
+    queue = bus.subscribe(EventTopic.BATTERY_CHANGE)
+    run_task = asyncio.create_task(daemon.run())
+
+    first = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert first == 80
+
+    second = await asyncio.wait_for(queue.get(), timeout=2.0)
+    assert second == 79
+
+    daemon.stop()
+    await run_task
+
+
+@pytest.mark.asyncio
+async def test_stop_idempotente():
+    fc = FakeController(transport="usb", states=_mk_states(5))
+    daemon = Daemon(controller=fc, config=DaemonConfig(poll_hz=60, auto_reconnect=False))
+    run_task = asyncio.create_task(daemon.run())
+    await asyncio.sleep(0.03)
+    daemon.stop()
+    daemon.stop()  # segundo stop é noop
+    await run_task
+
+
+@pytest.mark.asyncio
+async def test_daemon_desconecta_no_shutdown():
+    fc = FakeController(transport="usb", states=_mk_states(5))
+    daemon = Daemon(controller=fc, config=DaemonConfig(poll_hz=60, auto_reconnect=False))
+    run_task = asyncio.create_task(daemon.run())
+    await asyncio.sleep(0.03)
+    assert fc.is_connected() is True
+    daemon.stop()
+    await run_task
+    assert fc.is_connected() is False
+
+
+def test_battery_debounce_constants_coerentes_com_adr008():
+    # Sanidade cross-regra: ADR-008 + V2-17 exige 1%, 5s, min 100ms
+    from hefesto.daemon.lifecycle import (
+        BATTERY_DELTA_THRESHOLD_PCT,
+        BATTERY_MIN_INTERVAL_SEC,
+    )
+
+    assert BATTERY_DELTA_THRESHOLD_PCT == 1
+    assert BATTERY_DEBOUNCE_SEC == 5.0
+    assert BATTERY_MIN_INTERVAL_SEC == 0.1


### PR DESCRIPTION
## Resumo
Loop principal do daemon com poll 60Hz, shutdown limpo e runtime-real validado contra FakeController em USB e BT (meta-regra 9.8).

## Escopo
- `Daemon` orquestra connect with retry, poll_loop em ThreadPoolExecutor, signal handlers, shutdown completo.
- `BatteryDebouncer` V2-17 isolado e testavel: delta>=1% OU elapsed>=5s, min 100ms entre eventos.
- `structlog` configurado com formato console/json via env.
- CLI `hefesto daemon start` com --poll-hz, --foreground, --headless, --reconnect.
- `run.sh --smoke [--usb|--bt]` cumpre meta-regra 9.8.

## Runtime checks
- `scripts/check_anonymity.sh`: OK
- `ruff check`: pass
- `mypy` (strict, 19 arquivos): pass
- `pytest tests/unit -v`: **60 passed**
- `./run.sh --smoke`: 58 ticks em 2s USB
- `./run.sh --smoke --bt`: 58 ticks em 2s BT

Closes #3