### PR TITLE
W2.1: 19 trigger effect factories

### DIFF
--- a/src/hefesto/core/trigger_effects.py
+++ b/src/hefesto/core/trigger_effects.py
@@ -1,0 +1,366 @@
+"""Factories dos 19 presets de trigger conforme DSX Paliverse.
+
+Cada factory produz um `TriggerEffect` (definido em `hefesto.core.controller`)
+com `mode` low-level (valores do enum `pydualsense.TriggerModes`) e 7 bytes
+de `forces` no formato HID. Ver `docs/protocol/trigger-modes.md` para a
+tabela canônica e a distinção entre HID e presets.
+
+Todas as factories validam `ranges` e convertem amplitudes nomeadas (0-8)
+em bytes HID (0-255) multiplicando por `AMPLITUDE_SCALE`. Uso típico:
+
+    from hefesto.core.trigger_effects import galloping, machine
+    controller.set_trigger("right", galloping(0, 9, 7, 7, 10))
+    controller.set_trigger("left",  machine(0, 9, 3, 3, 50, 8))
+
+`TriggerMode` expõe os valores do enum do pydualsense sem exigir
+que o caller faça o import (mantém o backend trocável — ADR-001).
+"""
+from __future__ import annotations
+
+from enum import IntEnum
+
+from hefesto.core.controller import TriggerEffect
+
+AMPLITUDE_SCALE = 32  # Normaliza 0-8 (DSX) -> 0-255 (HID byte)
+
+
+class TriggerMode(IntEnum):
+    """Modos HID baixos aceitos pelo DualSense (espelha `pydualsense.TriggerModes`)."""
+
+    OFF = 0x00
+    RIGID = 0x01
+    PULSE = 0x02
+    RIGID_A = 0x01 | 0x20
+    RIGID_B = 0x01 | 0x04
+    RIGID_AB = 0x01 | 0x20 | 0x04
+    PULSE_A = 0x02 | 0x20
+    PULSE_B = 0x02 | 0x04
+    PULSE_AB = 0x02 | 0x20 | 0x04
+    CALIBRATION = 0xFC
+
+
+ZERO7 = (0, 0, 0, 0, 0, 0, 0)
+
+
+def _byte(value: int, *, name: str, lo: int = 0, hi: int = 255) -> int:
+    if not (lo <= value <= hi):
+        raise ValueError(f"{name} fora do range {lo}-{hi}: {value}")
+    return value
+
+
+def _amp(value: int, *, name: str) -> int:
+    """Converte amplitude nomeada (0-8) para byte HID com clamp em 255.
+
+    Fator 32 expande 0-7 para 0-224; 8 satura em 255 (byte máximo).
+    """
+    _byte(value, name=name, lo=0, hi=8)
+    return min(255, value * AMPLITUDE_SCALE)
+
+
+def _pos(value: int, *, name: str) -> int:
+    return _byte(value, name=name, lo=0, hi=9)
+
+
+# ---------------------------------------------------------------------------
+# Presets nomeados (19 itens conforme docs/protocol/trigger-modes.md)
+# ---------------------------------------------------------------------------
+
+
+def off() -> TriggerEffect:
+    return TriggerEffect(mode=TriggerMode.OFF, forces=ZERO7)
+
+
+def rigid(position: int, force: int) -> TriggerEffect:
+    """Barreira rígida numa posição. `position` 0-9, `force` 0-255."""
+    return TriggerEffect(
+        mode=TriggerMode.RIGID_B,
+        forces=(_pos(position, name="position"), _byte(force, name="force"), 0, 0, 0, 0, 0),
+    )
+
+
+def simple_rigid(strength: int) -> TriggerEffect:
+    """Atalho: rigid na base com força em escala 0-8."""
+    return TriggerEffect(
+        mode=TriggerMode.RIGID_B,
+        forces=(0, _amp(strength, name="strength"), 0, 0, 0, 0, 0),
+    )
+
+
+def pulse() -> TriggerEffect:
+    return TriggerEffect(mode=TriggerMode.PULSE, forces=ZERO7)
+
+
+def pulse_a(start: int, end: int, force: int) -> TriggerEffect:
+    _check_start_end(start, end)
+    s = _pos(start, name="start")
+    e = _pos(end, name="end")
+    f = _byte(force, name="force")
+    return TriggerEffect(mode=TriggerMode.PULSE_A, forces=(s, e, f, 0, 0, 0, 0))
+
+
+def pulse_b(start: int, end: int, force: int) -> TriggerEffect:
+    _check_start_end(start, end)
+    s = _pos(start, name="start")
+    e = _pos(end, name="end")
+    f = _byte(force, name="force")
+    return TriggerEffect(mode=TriggerMode.PULSE_B, forces=(s, e, f, 0, 0, 0, 0))
+
+
+def resistance(start: int, force: int) -> TriggerEffect:
+    """Resistência contínua a partir de `start` com força 0-8."""
+    return TriggerEffect(
+        mode=TriggerMode.RIGID_AB,
+        forces=(_pos(start, name="start"), _amp(force, name="force"), 0, 0, 0, 0, 0),
+    )
+
+
+def bow(start: int, end: int, force: int, snap: int) -> TriggerEffect:
+    """Simula arco: tensão crescente entre `start` e `end`, `snap` ao soltar."""
+    _byte(start, name="start", lo=0, hi=8)
+    _byte(end, name="end", lo=1, hi=9)
+    if end <= start:
+        raise ValueError(f"bow: end ({end}) deve ser > start ({start})")
+    return TriggerEffect(
+        mode=TriggerMode.PULSE_AB,
+        forces=(start, end, _amp(force, name="force"), _amp(snap, name="snap"), 0, 0, 0),
+    )
+
+
+def galloping(
+    start: int, end: int, first_foot: int, second_foot: int, frequency: int
+) -> TriggerEffect:
+    """Cadência de galope (5 params canônicos; HID usa 7 forces)."""
+    _byte(start, name="start", lo=0, hi=8)
+    _byte(end, name="end", lo=1, hi=9)
+    if end <= start:
+        raise ValueError(f"galloping: end ({end}) deve ser > start ({start})")
+    _byte(first_foot, name="first_foot", lo=0, hi=7)
+    _byte(second_foot, name="second_foot", lo=0, hi=7)
+    _byte(frequency, name="frequency")
+    return TriggerEffect(
+        mode=TriggerMode.PULSE_AB,
+        forces=(start, end, first_foot, second_foot, frequency, 0, 0),
+    )
+
+
+def semi_auto_gun(start: int, end: int, force: int) -> TriggerEffect:
+    _byte(start, name="start", lo=2, hi=7)
+    _byte(end, name="end", lo=start + 1, hi=8)
+    return TriggerEffect(
+        mode=TriggerMode.PULSE_AB,
+        forces=(start, end, _amp(force, name="force"), 0, 0, 0, 0),
+    )
+
+
+def auto_gun(start: int, strength: int, frequency: int) -> TriggerEffect:
+    return TriggerEffect(
+        mode=TriggerMode.PULSE_AB,
+        forces=(
+            _pos(start, name="start"),
+            _amp(strength, name="strength"),
+            _byte(frequency, name="frequency"),
+            0,
+            0,
+            0,
+            0,
+        ),
+    )
+
+
+def machine(
+    start: int, end: int, amp_a: int, amp_b: int, frequency: int, period: int
+) -> TriggerEffect:
+    """Machine gun style. 6 params nomeados, HID usa 7 forces (última zero)."""
+    _check_start_end(start, end)
+    return TriggerEffect(
+        mode=TriggerMode.PULSE_AB,
+        forces=(
+            start,
+            end,
+            _byte(amp_a, name="amp_a"),
+            _byte(amp_b, name="amp_b"),
+            _byte(frequency, name="frequency"),
+            _byte(period, name="period"),
+            0,
+        ),
+    )
+
+
+def feedback(position: int, strength: int) -> TriggerEffect:
+    return TriggerEffect(
+        mode=TriggerMode.RIGID_B,
+        forces=(_pos(position, name="position"), _amp(strength, name="strength"), 0, 0, 0, 0, 0),
+    )
+
+
+def weapon(start: int, end: int, force: int) -> TriggerEffect:
+    _check_start_end(start, end)
+    return TriggerEffect(
+        mode=TriggerMode.PULSE_B,
+        forces=(start, end, _byte(force, name="force"), 0, 0, 0, 0),
+    )
+
+
+def vibration(position: int, amplitude: int, frequency: int) -> TriggerEffect:
+    return TriggerEffect(
+        mode=TriggerMode.PULSE_A,
+        forces=(
+            _pos(position, name="position"),
+            _amp(amplitude, name="amplitude"),
+            _byte(frequency, name="frequency"),
+            0,
+            0,
+            0,
+            0,
+        ),
+    )
+
+
+def slope_feedback(
+    start: int, end: int, start_strength: int, end_strength: int
+) -> TriggerEffect:
+    _check_start_end(start, end)
+    _byte(start_strength, name="start_strength", lo=1, hi=8)
+    _byte(end_strength, name="end_strength", lo=1, hi=8)
+    return TriggerEffect(
+        mode=TriggerMode.RIGID_AB,
+        forces=(
+            start,
+            end,
+            min(255, start_strength * AMPLITUDE_SCALE),
+            min(255, end_strength * AMPLITUDE_SCALE),
+            0,
+            0,
+            0,
+        ),
+    )
+
+
+def multi_position_feedback(strengths: list[int]) -> TriggerEffect:
+    """Strength por posição (array de 10). Empacota em bits HID."""
+    if len(strengths) != 10:
+        raise ValueError(f"multi_position_feedback: precisa 10 strengths, recebeu {len(strengths)}")
+    for idx, s in enumerate(strengths):
+        _byte(s, name=f"strengths[{idx}]", lo=0, hi=8)
+    packed = _pack_strengths_bits(strengths)
+    return TriggerEffect(mode=TriggerMode.RIGID_AB, forces=packed)
+
+
+def multi_position_vibration(frequency: int, strengths: list[int]) -> TriggerEffect:
+    if len(strengths) != 10:
+        raise ValueError(
+            f"multi_position_vibration: precisa 10 strengths, recebeu {len(strengths)}"
+        )
+    for idx, s in enumerate(strengths):
+        _byte(s, name=f"strengths[{idx}]", lo=0, hi=8)
+    packed_bits = _pack_strengths_bits(strengths)
+    return TriggerEffect(
+        mode=TriggerMode.PULSE_A,
+        forces=(_byte(frequency, name="frequency"), *packed_bits[:6]),
+    )
+
+
+def custom(mode: int, forces: tuple[int, ...]) -> TriggerEffect:
+    """Escape hatch: envia mode + forces cru. Útil para experimentação."""
+    if len(forces) != 7:
+        raise ValueError(f"custom: forces precisa 7 elementos, recebeu {len(forces)}")
+    fixed: tuple[int, int, int, int, int, int, int] = (
+        forces[0], forces[1], forces[2], forces[3], forces[4], forces[5], forces[6]
+    )
+    return TriggerEffect(mode=mode, forces=fixed)
+
+
+# ---------------------------------------------------------------------------
+# Helpers internos
+# ---------------------------------------------------------------------------
+
+
+def _check_start_end(start: int, end: int) -> None:
+    _pos(start, name="start")
+    _pos(end, name="end")
+    if end <= start:
+        raise ValueError(f"end ({end}) deve ser > start ({start})")
+
+
+def _pack_strengths_bits(
+    strengths: list[int],
+) -> tuple[int, int, int, int, int, int, int]:
+    """Empacota 10 strengths (0-8) em bits HID.
+
+    Cada posição usa 3 bits. 10 * 3 = 30 bits, cabe em 4 bytes. Restantes
+    preenchidos com 0. Layout: bytes low-endian sequenciais.
+    """
+    bits = 0
+    for i, s in enumerate(strengths):
+        bits |= (s & 0x7) << (i * 3)
+    b0 = bits & 0xFF
+    b1 = (bits >> 8) & 0xFF
+    b2 = (bits >> 16) & 0xFF
+    b3 = (bits >> 24) & 0xFF
+    return (b0, b1, b2, b3, 0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Registry de presets por nome (CLI e perfis JSON referenciam por string).
+# ---------------------------------------------------------------------------
+
+
+PRESET_FACTORIES = {
+    "Off": off,
+    "Rigid": rigid,
+    "SimpleRigid": simple_rigid,
+    "Pulse": pulse,
+    "PulseA": pulse_a,
+    "PulseB": pulse_b,
+    "Resistance": resistance,
+    "Bow": bow,
+    "Galloping": galloping,
+    "SemiAutoGun": semi_auto_gun,
+    "AutoGun": auto_gun,
+    "Machine": machine,
+    "Feedback": feedback,
+    "Weapon": weapon,
+    "Vibration": vibration,
+    "SlopeFeedback": slope_feedback,
+    "MultiPositionFeedback": multi_position_feedback,
+    "MultiPositionVibration": multi_position_vibration,
+    "Custom": custom,
+}
+
+
+def build_from_name(name: str, params: list[int] | dict[str, int]) -> TriggerEffect:
+    """Resolve preset por nome + params. Aceita posicional (list) ou nomeado (dict)."""
+    from typing import Any, cast
+    factory = cast("Any", PRESET_FACTORIES.get(name))
+    if factory is None:
+        raise ValueError(f"preset desconhecido: {name}")
+    result = factory(**params) if isinstance(params, dict) else factory(*params)
+    assert isinstance(result, TriggerEffect)
+    return result
+
+
+__all__ = [
+    "AMPLITUDE_SCALE",
+    "PRESET_FACTORIES",
+    "TriggerMode",
+    "auto_gun",
+    "bow",
+    "build_from_name",
+    "custom",
+    "feedback",
+    "galloping",
+    "machine",
+    "multi_position_feedback",
+    "multi_position_vibration",
+    "off",
+    "pulse",
+    "pulse_a",
+    "pulse_b",
+    "resistance",
+    "rigid",
+    "semi_auto_gun",
+    "simple_rigid",
+    "slope_feedback",
+    "vibration",
+    "weapon",
+]

--- a/tests/unit/test_trigger_effects.py
+++ b/tests/unit/test_trigger_effects.py
@@ -1,0 +1,222 @@
+"""Testes dos 19 trigger effect factories."""
+from __future__ import annotations
+
+import pytest
+
+from hefesto.core import trigger_effects as tfx
+from hefesto.core.trigger_effects import (
+    AMPLITUDE_SCALE,
+    PRESET_FACTORIES,
+    TriggerMode,
+    build_from_name,
+)
+
+
+class TestBasicos:
+    def test_off(self):
+        eff = tfx.off()
+        assert eff.mode == TriggerMode.OFF
+        assert eff.forces == (0, 0, 0, 0, 0, 0, 0)
+
+    def test_rigid_valores_canonicos(self):
+        eff = tfx.rigid(5, 200)
+        assert eff.mode == TriggerMode.RIGID_B
+        assert eff.forces == (5, 200, 0, 0, 0, 0, 0)
+
+    def test_rigid_position_fora_de_range(self):
+        with pytest.raises(ValueError, match="position"):
+            tfx.rigid(10, 0)
+
+    def test_rigid_force_fora_de_byte(self):
+        with pytest.raises(ValueError, match="force"):
+            tfx.rigid(0, 300)
+
+    def test_simple_rigid_usa_amp_scale(self):
+        eff = tfx.simple_rigid(7)  # 7*32 = 224, sem clamp
+        assert eff.forces[1] == 7 * AMPLITUDE_SCALE
+
+    def test_simple_rigid_8_satura_no_byte(self):
+        eff = tfx.simple_rigid(8)
+        assert eff.forces[1] == 255  # clamp em byte
+
+    def test_pulse(self):
+        eff = tfx.pulse()
+        assert eff.mode == TriggerMode.PULSE
+        assert eff.forces == (0, 0, 0, 0, 0, 0, 0)
+
+
+class TestPulseAB:
+    def test_pulse_a(self):
+        eff = tfx.pulse_a(2, 7, 180)
+        assert eff.mode == TriggerMode.PULSE_A
+        assert eff.forces == (2, 7, 180, 0, 0, 0, 0)
+
+    def test_pulse_b(self):
+        eff = tfx.pulse_b(2, 7, 180)
+        assert eff.mode == TriggerMode.PULSE_B
+        assert eff.forces == (2, 7, 180, 0, 0, 0, 0)
+
+    def test_end_menor_ou_igual_start_rejeita(self):
+        with pytest.raises(ValueError, match="end"):
+            tfx.pulse_a(5, 5, 100)
+        with pytest.raises(ValueError, match="end"):
+            tfx.pulse_b(5, 3, 100)
+
+
+class TestResistance:
+    def test_mapeamento(self):
+        eff = tfx.resistance(3, 5)
+        assert eff.mode == TriggerMode.RIGID_AB
+        assert eff.forces == (3, 5 * AMPLITUDE_SCALE, 0, 0, 0, 0, 0)
+
+
+class TestBow:
+    def test_canonico(self):
+        eff = tfx.bow(1, 7, 7, 7)
+        assert eff.mode == TriggerMode.PULSE_AB
+        assert eff.forces == (1, 7, 7 * AMPLITUDE_SCALE, 7 * AMPLITUDE_SCALE, 0, 0, 0)
+
+    def test_force_8_satura(self):
+        eff = tfx.bow(1, 7, 8, 8)
+        assert eff.forces[2] == 255
+        assert eff.forces[3] == 255
+
+    def test_end_menor_rejeita(self):
+        with pytest.raises(ValueError, match="end"):
+            tfx.bow(5, 5, 4, 4)
+
+
+class TestGalloping:
+    def test_canonico(self):
+        eff = tfx.galloping(0, 9, 7, 7, 10)
+        assert eff.mode == TriggerMode.PULSE_AB
+        assert eff.forces == (0, 9, 7, 7, 10, 0, 0)
+
+    def test_frequency_aceita_0_a_255(self):
+        eff = tfx.galloping(0, 9, 0, 0, 255)
+        assert eff.forces[4] == 255
+
+    def test_foot_fora_de_0_7(self):
+        with pytest.raises(ValueError, match="first_foot"):
+            tfx.galloping(0, 9, 8, 0, 10)
+        with pytest.raises(ValueError, match="second_foot"):
+            tfx.galloping(0, 9, 0, 8, 10)
+
+
+class TestGuns:
+    def test_semi_auto_gun(self):
+        eff = tfx.semi_auto_gun(3, 6, 5)
+        assert eff.mode == TriggerMode.PULSE_AB
+        assert eff.forces == (3, 6, 5 * AMPLITUDE_SCALE, 0, 0, 0, 0)
+
+    def test_semi_auto_gun_start_fora(self):
+        with pytest.raises(ValueError, match="start"):
+            tfx.semi_auto_gun(1, 5, 3)
+
+    def test_semi_auto_gun_end_invalido(self):
+        with pytest.raises(ValueError, match="end"):
+            tfx.semi_auto_gun(3, 3, 3)
+
+    def test_auto_gun(self):
+        eff = tfx.auto_gun(2, 6, 100)
+        assert eff.mode == TriggerMode.PULSE_AB
+        assert eff.forces == (2, 6 * AMPLITUDE_SCALE, 100, 0, 0, 0, 0)
+
+    def test_weapon(self):
+        eff = tfx.weapon(2, 5, 200)
+        assert eff.mode == TriggerMode.PULSE_B
+        assert eff.forces == (2, 5, 200, 0, 0, 0, 0)
+
+
+class TestMachine:
+    def test_canonico_6_params_produz_7_forces(self):
+        eff = tfx.machine(0, 9, 3, 3, 50, 8)
+        assert eff.mode == TriggerMode.PULSE_AB
+        assert eff.forces == (0, 9, 3, 3, 50, 8, 0)  # última sempre 0
+
+    def test_end_menor_rejeita(self):
+        with pytest.raises(ValueError, match="end"):
+            tfx.machine(5, 5, 0, 0, 0, 0)
+
+
+class TestFeedbackEVibration:
+    def test_feedback(self):
+        eff = tfx.feedback(5, 4)
+        assert eff.mode == TriggerMode.RIGID_B
+        assert eff.forces == (5, 4 * AMPLITUDE_SCALE, 0, 0, 0, 0, 0)
+
+    def test_vibration(self):
+        eff = tfx.vibration(3, 4, 40)
+        assert eff.mode == TriggerMode.PULSE_A
+        assert eff.forces == (3, 4 * AMPLITUDE_SCALE, 40, 0, 0, 0, 0)
+
+    def test_slope_feedback(self):
+        eff = tfx.slope_feedback(1, 8, 2, 7)
+        assert eff.mode == TriggerMode.RIGID_AB
+        assert eff.forces == (1, 8, 2 * AMPLITUDE_SCALE, 7 * AMPLITUDE_SCALE, 0, 0, 0)
+
+    def test_slope_feedback_strength_0_rejeita(self):
+        with pytest.raises(ValueError, match="start_strength"):
+            tfx.slope_feedback(1, 8, 0, 7)
+
+
+class TestMultiPosition:
+    def test_feedback_packing(self):
+        strengths = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1]
+        eff = tfx.multi_position_feedback(strengths)
+        assert eff.mode == TriggerMode.RIGID_AB
+        # Reconstitui bits pra conferir
+        bits = 0
+        for i, s in enumerate(strengths):
+            bits |= (s & 0x7) << (i * 3)
+        assert eff.forces[0] == (bits & 0xFF)
+        assert eff.forces[1] == ((bits >> 8) & 0xFF)
+        assert eff.forces[2] == ((bits >> 16) & 0xFF)
+        assert eff.forces[3] == ((bits >> 24) & 0xFF)
+
+    def test_feedback_strengths_9_rejeita(self):
+        with pytest.raises(ValueError, match="10 strengths"):
+            tfx.multi_position_feedback([0] * 9)
+
+    def test_feedback_valor_acima_8_rejeita(self):
+        bad = [0, 0, 9, 0, 0, 0, 0, 0, 0, 0]
+        with pytest.raises(ValueError, match="strengths\\[2\\]"):
+            tfx.multi_position_feedback(bad)
+
+    def test_vibration(self):
+        eff = tfx.multi_position_vibration(100, [0] * 10)
+        assert eff.mode == TriggerMode.PULSE_A
+        assert eff.forces[0] == 100
+
+
+class TestCustomEBuild:
+    def test_custom_passa_forces_cru(self):
+        eff = tfx.custom(TriggerMode.PULSE_AB, (0, 9, 7, 7, 10, 0, 0))
+        assert eff.mode == TriggerMode.PULSE_AB
+        assert eff.forces == (0, 9, 7, 7, 10, 0, 0)
+
+    def test_custom_arity_errada_rejeita(self):
+        with pytest.raises(ValueError, match="forces precisa"):
+            tfx.custom(0, (0, 0, 0))
+
+    def test_build_from_name_posicional(self):
+        eff = build_from_name("Galloping", [0, 9, 7, 7, 10])
+        assert eff.mode == TriggerMode.PULSE_AB
+        assert eff.forces == (0, 9, 7, 7, 10, 0, 0)
+
+    def test_build_from_name_nomeado(self):
+        eff = build_from_name("Rigid", {"position": 5, "force": 200})
+        assert eff.forces == (5, 200, 0, 0, 0, 0, 0)
+
+    def test_build_from_name_desconhecido(self):
+        with pytest.raises(ValueError, match="preset desconhecido"):
+            build_from_name("Inexistente", [])
+
+
+def test_registry_tem_19_presets():
+    assert len(PRESET_FACTORIES) == 19
+
+
+def test_todos_os_presets_chave_retornam_callable():
+    for name, factory in PRESET_FACTORIES.items():
+        assert callable(factory), f"{name} nao eh callable"


### PR DESCRIPTION
## Resumo
19 presets de trigger do DSX implementados sobre os 10 modos HID low-level.

## Escopo
- `TriggerMode` enum espelha `pydualsense.TriggerModes` (backend trocavel).
- 19 factories com validacao de ranges, conversao amplitude->byte e clamp em 255.
- `_pack_strengths_bits` empacota 10 strengths (3 bits cada) em 4 bytes para multi_position_*.
- `PRESET_FACTORIES` registry por nome + `build_from_name` para perfis JSON e CLI.

## Runtime checks
- `ruff check`: pass
- `mypy` (strict, 20 arquivos): pass
- `pytest tests/unit -v`: **99 passed**
- `scripts/check_anonymity.sh`: OK

Closes #4