### PR TITLE
W2.2: LED control + rumble com throttle

### DIFF
--- a/src/hefesto/core/led_control.py
+++ b/src/hefesto/core/led_control.py
@@ -1,0 +1,80 @@
+"""Controle de LEDs do DualSense.
+
+API de alto nível: lightbar RGB, 5 LEDs de jogador (bitmask) e LED do microfone.
+O backend (`IController.set_led`) só aceita a cor da lightbar hoje; os player
+LEDs e o mic LED dependem de API complementar no backend (a adicionar quando
+houver necessidade em W5.x). Aqui expomos dataclasses de configuração que a
+TUI e os perfis consomem.
+
+Uso:
+    from hefesto.core.led_control import LedSettings, apply_led_settings
+    apply_led_settings(controller, LedSettings(lightbar=(255, 128, 0)))
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hefesto.core.controller import IController
+
+RGB = tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class LedSettings:
+    """Configuração imutável de LEDs.
+
+    - `lightbar`: RGB 0-255 cada.
+    - `player_leds`: lista de 5 booleanos para os indicadores inferiores
+      (esquerda para direita). Padrão: todos apagados.
+    - `mic_led`: estado do LED do microfone (True=ligado).
+    """
+
+    lightbar: RGB
+    player_leds: tuple[bool, bool, bool, bool, bool] = (False, False, False, False, False)
+    mic_led: bool = False
+
+    def __post_init__(self) -> None:
+        if len(self.lightbar) != 3:
+            raise ValueError(f"lightbar precisa 3 componentes, recebeu {len(self.lightbar)}")
+        for idx, v in enumerate(self.lightbar):
+            if not (0 <= v <= 255):
+                raise ValueError(f"lightbar[{idx}] fora de byte: {v}")
+
+
+def player_bitmask(leds: tuple[bool, bool, bool, bool, bool]) -> int:
+    """Converte 5 flags em bitmask 0-31 (mesmo layout usado pelo protocolo DSX)."""
+    value = 0
+    for idx, on in enumerate(leds):
+        if on:
+            value |= 1 << idx
+    return value
+
+
+def apply_led_settings(controller: IController, settings: LedSettings) -> None:
+    """Aplica settings no controle. Usa apenas `set_led` por enquanto.
+
+    Player LEDs e mic LED são mantidos no `LedSettings` para serialização
+    de perfis; o backend completará quando expor API específica.
+    """
+    controller.set_led(settings.lightbar)
+
+
+def off() -> LedSettings:
+    return LedSettings(lightbar=(0, 0, 0))
+
+
+def hex_to_rgb(hex_str: str) -> RGB:
+    """Converte '#RRGGBB' ou 'RRGGBB' para tupla (r, g, b)."""
+    s = hex_str.strip().lstrip("#")
+    if len(s) != 6:
+        raise ValueError(f"hex_to_rgb espera formato RRGGBB, recebeu: {hex_str!r}")
+    try:
+        r = int(s[0:2], 16)
+        g = int(s[2:4], 16)
+        b = int(s[4:6], 16)
+    except ValueError as exc:
+        raise ValueError(f"hex_to_rgb: componente nao numerico em {hex_str!r}") from exc
+    return (r, g, b)
+
+
+__all__ = ["RGB", "LedSettings", "apply_led_settings", "hex_to_rgb", "off", "player_bitmask"]

--- a/src/hefesto/core/rumble.py
+++ b/src/hefesto/core/rumble.py
@@ -1,0 +1,115 @@
+"""Motor de rumble com throttle anti-spam.
+
+Rumble passado do jogo (via UDP ou passthrough) pode chegar a centenas de
+Hz. Aplicar cada atualização esgota a bateria, satura o motor HID e
+deteriora os motors pequenos do DualSense. `RumbleEngine` agrupa os
+comandos recebidos numa janela curta e aplica só o último a cada tick
+de saída.
+
+Uso:
+    engine = RumbleEngine(controller, min_interval_sec=0.02)
+    engine.set(weak=80, strong=150)    # pode ser chamado 1000x/s
+    # tick() é chamado pelo poll loop do daemon e aplica se janela
+    # estourou. Também aplica automaticamente quando weak+strong cai
+    # para 0 (garantir desligamento imediato).
+"""
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from hefesto.core.controller import IController
+
+DEFAULT_MIN_INTERVAL_SEC = 0.02  # 50Hz ceiling para motores HID
+RUMBLE_MIN = 0
+RUMBLE_MAX = 255
+
+
+@dataclass
+class RumbleCommand:
+    weak: int
+    strong: int
+
+    def is_stop(self) -> bool:
+        return self.weak == 0 and self.strong == 0
+
+
+class RumbleEngine:
+    """Throttle: aplica no máximo 1x por `min_interval_sec`, exceto stop.
+
+    Guarda o último comando pedido; `tick(now)` aplica se o intervalo
+    estourou OU se o comando é stop (0,0). Em stop o throttle é ignorado
+    para garantir desligamento imediato quando o jogo solta o gatilho.
+    """
+
+    def __init__(
+        self,
+        controller: IController,
+        min_interval_sec: float = DEFAULT_MIN_INTERVAL_SEC,
+        *,
+        time_fn: Callable[[], float] | None = None,
+    ) -> None:
+        self._controller = controller
+        self._min_interval = min_interval_sec
+        self._time = time_fn or time.monotonic
+        self._pending: RumbleCommand | None = None
+        self._last_applied: RumbleCommand | None = None
+        self._last_applied_at: float = 0.0
+
+    def set(self, weak: int, strong: int) -> None:
+        weak = _clamp(weak)
+        strong = _clamp(strong)
+        self._pending = RumbleCommand(weak=weak, strong=strong)
+
+    def tick(self) -> RumbleCommand | None:
+        """Aplica `pending` se tempo permitir. Retorna o comando aplicado ou None."""
+        if self._pending is None:
+            return None
+
+        now = self._time()
+        cmd = self._pending
+
+        if cmd.is_stop():
+            return self._apply(cmd, now)
+
+        if self._last_applied is None:
+            return self._apply(cmd, now)
+
+        interval = now - self._last_applied_at
+        if interval >= self._min_interval:
+            return self._apply(cmd, now)
+        return None
+
+    def stop(self) -> None:
+        """Forçar desligamento imediato dos motores."""
+        self.set(0, 0)
+        self.tick()
+
+    @property
+    def last_applied(self) -> RumbleCommand | None:
+        return self._last_applied
+
+    def _apply(self, cmd: RumbleCommand, now: float) -> RumbleCommand:
+        self._controller.set_rumble(weak=cmd.weak, strong=cmd.strong)
+        self._last_applied = cmd
+        self._last_applied_at = now
+        self._pending = None
+        return cmd
+
+
+def _clamp(value: int) -> int:
+    if value < RUMBLE_MIN:
+        return RUMBLE_MIN
+    if value > RUMBLE_MAX:
+        return RUMBLE_MAX
+    return value
+
+
+__all__ = [
+    "DEFAULT_MIN_INTERVAL_SEC",
+    "RUMBLE_MAX",
+    "RUMBLE_MIN",
+    "RumbleCommand",
+    "RumbleEngine",
+]

--- a/tests/unit/test_led_and_rumble.py
+++ b/tests/unit/test_led_and_rumble.py
@@ -1,0 +1,159 @@
+"""Testes de LED control e rumble com throttle."""
+from __future__ import annotations
+
+import pytest
+
+from hefesto.core.led_control import (
+    LedSettings,
+    apply_led_settings,
+    hex_to_rgb,
+    off,
+    player_bitmask,
+)
+from hefesto.core.rumble import (
+    DEFAULT_MIN_INTERVAL_SEC,
+    RumbleCommand,
+    RumbleEngine,
+)
+from tests.fixtures.fake_controller import FakeController
+
+
+class TestLedSettings:
+    def test_defaults(self):
+        s = LedSettings(lightbar=(255, 0, 128))
+        assert s.lightbar == (255, 0, 128)
+        assert s.player_leds == (False, False, False, False, False)
+        assert s.mic_led is False
+
+    def test_componente_fora_de_byte_rejeita(self):
+        with pytest.raises(ValueError, match="lightbar"):
+            LedSettings(lightbar=(300, 0, 0))
+
+    def test_tamanho_errado_rejeita(self):
+        with pytest.raises(ValueError, match="3 componentes"):
+            LedSettings(lightbar=(10, 20))  # type: ignore[arg-type]
+
+    def test_off_helper(self):
+        assert off().lightbar == (0, 0, 0)
+
+
+class TestApplyLedSettings:
+    def test_chama_set_led_no_controller(self):
+        fc = FakeController()
+        fc.connect()
+        apply_led_settings(fc, LedSettings(lightbar=(100, 200, 50)))
+        leds = [c for c in fc.commands if c.kind == "set_led"]
+        assert len(leds) == 1
+        assert leds[0].payload == (100, 200, 50)
+
+
+class TestPlayerBitmask:
+    def test_todos_apagados(self):
+        assert player_bitmask((False, False, False, False, False)) == 0
+
+    def test_todos_acesos(self):
+        assert player_bitmask((True, True, True, True, True)) == 31
+
+    def test_alternados(self):
+        assert player_bitmask((True, False, True, False, True)) == 0b10101
+
+
+class TestHexToRgb:
+    def test_com_hash(self):
+        assert hex_to_rgb("#FF8000") == (255, 128, 0)
+
+    def test_sem_hash(self):
+        assert hex_to_rgb("ff8000") == (255, 128, 0)
+
+    def test_invalido(self):
+        with pytest.raises(ValueError, match="RRGGBB"):
+            hex_to_rgb("#F80")
+        with pytest.raises(ValueError, match="nao numerico"):
+            hex_to_rgb("#ZZZZZZ")
+
+
+class TestRumbleEngine:
+    def _mk_engine(self, interval: float = DEFAULT_MIN_INTERVAL_SEC):
+        fc = FakeController()
+        fc.connect()
+        clock = {"t": 0.0}
+
+        def now() -> float:
+            return clock["t"]
+
+        engine = RumbleEngine(fc, min_interval_sec=interval, time_fn=now)
+        return fc, engine, clock
+
+    def test_primeiro_tick_aplica(self):
+        fc, engine, _clock = self._mk_engine(interval=0.02)
+        engine.set(100, 200)
+        applied = engine.tick()
+        assert applied == RumbleCommand(weak=100, strong=200)
+        rumbles = [c for c in fc.commands if c.kind == "set_rumble"]
+        assert rumbles[-1].payload == (100, 200)
+
+    def test_segundo_tick_respeita_throttle(self):
+        _fc, engine, clock = self._mk_engine(interval=0.02)
+        engine.set(100, 200)
+        engine.tick()
+        clock["t"] += 0.005
+        engine.set(150, 50)
+        applied = engine.tick()
+        assert applied is None  # dentro da janela — suprime
+
+    def test_depois_do_intervalo_aplica_valor_mais_recente(self):
+        _fc, engine, clock = self._mk_engine(interval=0.02)
+        engine.set(100, 200)
+        engine.tick()
+        clock["t"] += 0.03  # passa janela
+        engine.set(150, 50)
+        applied = engine.tick()
+        assert applied == RumbleCommand(weak=150, strong=50)
+
+    def test_stop_ignora_throttle_e_aplica_imediato(self):
+        _fc, engine, clock = self._mk_engine(interval=0.5)
+        engine.set(100, 200)
+        engine.tick()  # aplicou
+        clock["t"] += 0.01  # dentro da janela
+        engine.set(0, 0)
+        applied = engine.tick()
+        assert applied is not None
+        assert applied.is_stop()
+
+    def test_tick_sem_pending_retorna_none(self):
+        _fc, engine, _clock = self._mk_engine()
+        assert engine.tick() is None
+
+    def test_clamp_de_valores(self):
+        fc, engine, _clock = self._mk_engine(interval=0.02)
+        engine.set(-50, 500)
+        engine.tick()
+        rumbles = [c for c in fc.commands if c.kind == "set_rumble"]
+        assert rumbles[-1].payload == (0, 255)
+
+    def test_flood_suprimido_mas_ultimo_valor_pendente_aplicado(self):
+        # Janela grande (0.5s) > soma dos deltas do loop (100 * 0.001 = 0.1s)
+        # garante que só o tick inicial aplica durante o flood.
+        fc, engine, clock = self._mk_engine(interval=0.5)
+        engine.set(10, 20)
+        engine.tick()
+        for i in range(100):
+            engine.set(50 + i % 10, 100 + i % 10)
+            clock["t"] += 0.001
+            engine.tick()
+        rumbles = [c for c in fc.commands if c.kind == "set_rumble"]
+        assert len(rumbles) == 1
+        clock["t"] += 0.5
+        applied = engine.tick()
+        assert applied is not None
+        rumbles = [c for c in fc.commands if c.kind == "set_rumble"]
+        assert len(rumbles) == 2
+
+    def test_stop_via_metodo_explicito(self):
+        _fc, engine, clock = self._mk_engine(interval=0.5)
+        engine.set(200, 200)
+        engine.tick()
+        clock["t"] += 0.01
+        engine.stop()
+        assert engine.last_applied is not None
+        assert engine.last_applied.is_stop()


### PR DESCRIPTION
## Resumo
LedSettings imutavel + RumbleEngine com throttle para proteger motores e bateria.

## Escopo
- `LedSettings` (frozen) com lightbar, player_leds, mic_led. Validacao de ranges.
- `apply_led_settings`, `player_bitmask`, `hex_to_rgb`, `off`.
- `RumbleEngine` com throttle configuravel (default 20ms), clamp 0-255, stop imediato que ignora throttle, `time_fn` injetavel para testes.
- 19 testes novos (118 total).

## Runtime checks
- `ruff check`: pass
- `mypy` (strict, 22 arquivos): pass
- `pytest tests/unit -v`: **118 passed**
- `scripts/check_anonymity.sh`: OK

Closes #5