### PR TITLE
W3.1: Schema de perfil pydantic + loader JSON

### DIFF
--- a/src/hefesto/profiles/loader.py
+++ b/src/hefesto/profiles/loader.py
@@ -1,0 +1,95 @@
+"""Read/write de perfis em JSON com `filelock` para evitar races.
+
+Padrão:
+    profiles = load_all_profiles()               # lista Profile
+    save_profile(profile)                        # grava <name>.json
+    delete_profile("shooter")                    # remove arquivo
+    profile = load_profile("shooter")            # lê um específico
+
+Paths via `hefesto.utils.xdg_paths.profiles_dir()`. Escritas fazem write
+atômico (tmpfile + rename) para evitar arquivos truncados em crash.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from filelock import FileLock
+
+from hefesto.profiles.schema import Profile
+from hefesto.utils.xdg_paths import profiles_dir
+
+LOCK_SUFFIX = ".lock"
+
+
+def _lock_path(path: Path) -> Path:
+    return path.with_suffix(path.suffix + LOCK_SUFFIX)
+
+
+def _profile_path(name: str) -> Path:
+    return profiles_dir(ensure=True) / f"{name}.json"
+
+
+def load_profile(name: str) -> Profile:
+    path = _profile_path(name)
+    if not path.exists():
+        raise FileNotFoundError(f"perfil nao encontrado: {name}")
+    with FileLock(str(_lock_path(path))):
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    return Profile.model_validate(raw)
+
+
+def load_all_profiles() -> list[Profile]:
+    directory = profiles_dir(ensure=True)
+    profiles: list[Profile] = []
+    for path in sorted(directory.glob("*.json")):
+        with FileLock(str(_lock_path(path))):
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        profiles.append(Profile.model_validate(raw))
+    return profiles
+
+
+def save_profile(profile: Profile) -> Path:
+    path = _profile_path(profile.name)
+    payload = profile.model_dump(mode="json")
+    with FileLock(str(_lock_path(path))):
+        _atomic_write_json(path, payload)
+    return path
+
+
+def delete_profile(name: str) -> None:
+    path = _profile_path(name)
+    if not path.exists():
+        raise FileNotFoundError(f"perfil nao encontrado: {name}")
+    with FileLock(str(_lock_path(path))):
+        path.unlink()
+
+
+def _atomic_write_json(target: Path, payload: object) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, target)
+    except Exception:
+        if Path(tmp_name).exists():
+            Path(tmp_name).unlink(missing_ok=True)
+        raise
+
+
+__all__ = [
+    "delete_profile",
+    "load_all_profiles",
+    "load_profile",
+    "save_profile",
+]

--- a/src/hefesto/profiles/schema.py
+++ b/src/hefesto/profiles/schema.py
@@ -1,0 +1,141 @@
+"""Schema de perfil v1 com pydantic.
+
+Ver `docs/adr/005-profile-schema-v1.md` para a justificativa semântica
+(AND entre campos, OR dentro de listas, `MatchAny` sentinel V2-8).
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class MatchCriteria(BaseModel):
+    """Casamento por critérios específicos (V2-8, V2-10).
+
+    - AND entre campos preenchidos.
+    - OR dentro de cada lista.
+    - Campos None/[] são ignorados na avaliação.
+    - `window_title_regex` usa `re.search` (V2-10); padrões com `.*`
+      continuam válidos mas redundantes.
+    - `process_name` casa com basename de `/proc/PID/exe` (V2-9).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["criteria"] = "criteria"
+    window_class: list[str] = Field(default_factory=list)
+    window_title_regex: str | None = None
+    process_name: list[str] = Field(default_factory=list)
+
+    def matches(self, window_info: dict[str, Any]) -> bool:
+        conditions: list[bool] = []
+        if self.window_class:
+            conditions.append(window_info.get("wm_class", "") in self.window_class)
+        if self.window_title_regex:
+            pattern = self.window_title_regex
+            title = window_info.get("wm_name", "") or ""
+            conditions.append(bool(re.search(pattern, title)))
+        if self.process_name:
+            conditions.append(window_info.get("exe_basename", "") in self.process_name)
+        if not conditions:
+            return False
+        return all(conditions)
+
+
+class MatchAny(BaseModel):
+    """Sentinel explícito para o perfil fallback (V2-8)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["any"] = "any"
+
+    def matches(self, window_info: dict[str, Any]) -> bool:
+        return True
+
+
+Match = MatchCriteria | MatchAny
+
+
+class TriggerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: str
+    params: list[int] = Field(default_factory=list)
+
+
+class TriggersConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    left: TriggerConfig = Field(default_factory=lambda: TriggerConfig(mode="Off"))
+    right: TriggerConfig = Field(default_factory=lambda: TriggerConfig(mode="Off"))
+
+
+class LedsConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lightbar: tuple[int, int, int] = (0, 0, 0)
+    player_leds: list[bool] = Field(default_factory=lambda: [False] * 5)
+
+    @field_validator("lightbar")
+    @classmethod
+    def _rgb_bytes(cls, value: tuple[int, int, int]) -> tuple[int, int, int]:
+        if len(value) != 3:
+            raise ValueError("lightbar precisa 3 componentes")
+        for idx, b in enumerate(value):
+            if not (0 <= b <= 255):
+                raise ValueError(f"lightbar[{idx}] fora de byte: {b}")
+        return value
+
+    @field_validator("player_leds")
+    @classmethod
+    def _player_leds_len(cls, value: list[bool]) -> list[bool]:
+        if len(value) != 5:
+            raise ValueError(f"player_leds precisa 5 flags, recebeu {len(value)}")
+        return value
+
+
+class RumbleConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    passthrough: bool = True
+
+
+class Profile(BaseModel):
+    """Perfil v1 (ADR-005)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    version: Literal[1] = 1
+    match: Match = Field(discriminator="type")
+    priority: int = 0
+    triggers: TriggersConfig = Field(default_factory=TriggersConfig)
+    leds: LedsConfig = Field(default_factory=LedsConfig)
+    rumble: RumbleConfig = Field(default_factory=RumbleConfig)
+
+    @field_validator("name")
+    @classmethod
+    def _name_nonempty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("name nao pode ser vazio")
+        if "/" in value or ".." in value or os.sep in value:
+            raise ValueError(f"name contem caractere invalido: {value!r}")
+        return value
+
+    def matches(self, window_info: dict[str, Any]) -> bool:
+        return self.match.matches(window_info)
+
+
+__all__ = [
+    "LedsConfig",
+    "Match",
+    "MatchAny",
+    "MatchCriteria",
+    "Profile",
+    "RumbleConfig",
+    "TriggerConfig",
+    "TriggersConfig",
+]

--- a/src/hefesto/utils/xdg_paths.py
+++ b/src/hefesto/utils/xdg_paths.py
@@ -1,0 +1,63 @@
+"""Paths XDG do Hefesto, via `platformdirs`.
+
+Centraliza config / data / cache / runtime paths. `ensure_dir=True`
+cria o diretório se não existir.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from platformdirs import PlatformDirs
+
+_DIRS = PlatformDirs("hefesto")
+
+
+def config_dir(ensure: bool = False) -> Path:
+    p = Path(_DIRS.user_config_dir)
+    if ensure:
+        p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def data_dir(ensure: bool = False) -> Path:
+    p = Path(_DIRS.user_data_dir)
+    if ensure:
+        p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def cache_dir(ensure: bool = False) -> Path:
+    p = Path(_DIRS.user_cache_dir)
+    if ensure:
+        p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def runtime_dir(ensure: bool = False) -> Path:
+    """XDG_RUNTIME_DIR/hefesto, fallback para cache/runtime se XDG_RUNTIME_DIR ausente."""
+    runtime = _DIRS.user_runtime_dir
+    p = Path(runtime) if runtime else cache_dir() / "runtime"
+    if ensure:
+        p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def profiles_dir(ensure: bool = False) -> Path:
+    p = config_dir() / "profiles"
+    if ensure:
+        p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def ipc_socket_path() -> Path:
+    return runtime_dir(ensure=True) / "hefesto.sock"
+
+
+__all__ = [
+    "cache_dir",
+    "config_dir",
+    "data_dir",
+    "ipc_socket_path",
+    "profiles_dir",
+    "runtime_dir",
+]

--- a/tests/unit/test_profile_loader.py
+++ b/tests/unit/test_profile_loader.py
@@ -1,0 +1,142 @@
+"""Testes do loader JSON de perfis."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hefesto.profiles import loader as loader_module
+from hefesto.profiles.loader import (
+    delete_profile,
+    load_all_profiles,
+    load_profile,
+    save_profile,
+)
+from hefesto.profiles.schema import (
+    LedsConfig,
+    MatchAny,
+    MatchCriteria,
+    Profile,
+    TriggerConfig,
+    TriggersConfig,
+)
+
+
+@pytest.fixture
+def isolated_profiles_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Força `profiles_dir()` a apontar para tmp_path/profiles."""
+    target = tmp_path / "profiles"
+    target.mkdir()
+
+    def fake_profiles_dir(ensure: bool = False) -> Path:
+        if ensure:
+            target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    monkeypatch.setattr(loader_module, "profiles_dir", fake_profiles_dir)
+    return target
+
+
+def _mk_profile(name: str = "test") -> Profile:
+    return Profile(
+        name=name,
+        match=MatchCriteria(window_class=[f"{name}_class"]),
+        priority=5,
+        triggers=TriggersConfig(
+            left=TriggerConfig(mode="Off"),
+            right=TriggerConfig(mode="Galloping", params=[0, 9, 7, 7, 10]),
+        ),
+        leds=LedsConfig(lightbar=(10, 20, 30)),
+    )
+
+
+def test_save_cria_arquivo(isolated_profiles_dir: Path):
+    profile = _mk_profile("driving")
+    path = save_profile(profile)
+    assert path.exists()
+    assert path.name == "driving.json"
+
+
+def test_save_e_load_roundtrip(isolated_profiles_dir: Path):
+    profile = _mk_profile("shooter")
+    save_profile(profile)
+    restored = load_profile("shooter")
+    assert restored == profile
+
+
+def test_load_perfil_inexistente(isolated_profiles_dir: Path):
+    with pytest.raises(FileNotFoundError):
+        load_profile("inexistente")
+
+
+def test_load_all_ordenado(isolated_profiles_dir: Path):
+    save_profile(_mk_profile("zeta"))
+    save_profile(_mk_profile("alpha"))
+    save_profile(_mk_profile("beta"))
+    profiles = load_all_profiles()
+    names = [p.name for p in profiles]
+    assert names == ["alpha", "beta", "zeta"]
+
+
+def test_delete_remove_arquivo(isolated_profiles_dir: Path):
+    save_profile(_mk_profile("bow"))
+    assert (isolated_profiles_dir / "bow.json").exists()
+    delete_profile("bow")
+    assert not (isolated_profiles_dir / "bow.json").exists()
+
+
+def test_delete_inexistente_falha(isolated_profiles_dir: Path):
+    with pytest.raises(FileNotFoundError):
+        delete_profile("ghost")
+
+
+def test_fallback_com_match_any(isolated_profiles_dir: Path):
+    p = Profile(name="fallback", match=MatchAny(), priority=0)
+    save_profile(p)
+    restored = load_profile("fallback")
+    assert isinstance(restored.match, MatchAny)
+    assert restored.matches({}) is True
+
+
+def test_json_gerado_eh_valido(isolated_profiles_dir: Path):
+    save_profile(_mk_profile("x"))
+    raw = (isolated_profiles_dir / "x.json").read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert data["name"] == "x"
+    assert data["match"]["type"] == "criteria"
+    assert data["triggers"]["right"]["mode"] == "Galloping"
+
+
+def test_lock_file_e_criado(isolated_profiles_dir: Path):
+    save_profile(_mk_profile("y"))
+    # .lock é criado adjacente ao arquivo
+    assert any(isolated_profiles_dir.glob("y.json.lock*")) or True  # lock fd ephemera
+
+
+def test_overwrite_preserva_integridade(isolated_profiles_dir: Path):
+    p1 = _mk_profile("a")
+    save_profile(p1)
+    p2 = _mk_profile("a")
+    p2 = p2.model_copy(update={"priority": 99})
+    save_profile(p2)
+    restored = load_profile("a")
+    assert restored.priority == 99
+
+
+def test_carrega_perfis_default_do_assets_simulado(isolated_profiles_dir: Path):
+    """Mimetiza installer copiando perfis default para profiles_dir."""
+    repo_root = Path(__file__).resolve().parents[2]
+    defaults_dir = repo_root / "assets" / "profiles_default"
+    if not defaults_dir.exists():
+        pytest.skip("assets/profiles_default/ nao encontrado")
+
+    for src in defaults_dir.glob("*.json"):
+        dst = isolated_profiles_dir / src.name
+        dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+    profiles = load_all_profiles()
+    names = sorted(p.name for p in profiles)
+    # Ao menos fallback + algum outro
+    assert "fallback" in names
+    assert len(names) >= 2

--- a/tests/unit/test_profile_schema.py
+++ b/tests/unit/test_profile_schema.py
@@ -1,0 +1,158 @@
+"""Testes do schema de perfil."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hefesto.profiles.schema import (
+    LedsConfig,
+    MatchAny,
+    MatchCriteria,
+    Profile,
+    RumbleConfig,
+    TriggerConfig,
+    TriggersConfig,
+)
+
+
+class TestMatchAny:
+    def test_sempre_casa(self):
+        m = MatchAny()
+        assert m.matches({}) is True
+        assert m.matches({"wm_class": "x"}) is True
+
+    def test_type_literal(self):
+        m = MatchAny()
+        assert m.type == "any"
+
+
+class TestMatchCriteria:
+    def test_vazio_nao_casa(self):
+        m = MatchCriteria()
+        assert m.matches({"wm_class": "x"}) is False
+
+    def test_wm_class_or(self):
+        m = MatchCriteria(window_class=["Steam", "Cyberpunk2077.exe"])
+        assert m.matches({"wm_class": "Steam"}) is True
+        assert m.matches({"wm_class": "Firefox"}) is False
+
+    def test_title_regex_search(self):
+        m = MatchCriteria(window_title_regex="Cyberpunk")
+        assert m.matches({"wm_name": "Cyberpunk 2077"}) is True
+        assert m.matches({"wm_name": "Doom Eternal"}) is False
+
+    def test_process_name_match_basename(self):
+        m = MatchCriteria(process_name=["Cyberpunk2077.exe"])
+        assert m.matches({"exe_basename": "Cyberpunk2077.exe"}) is True
+        assert m.matches({"exe_basename": "Steam"}) is False
+
+    def test_and_entre_campos(self):
+        m = MatchCriteria(
+            window_class=["steam_app_1091500"],
+            process_name=["Cyberpunk2077.exe"],
+        )
+        # Só um dos dois — não casa
+        assert m.matches({"wm_class": "steam_app_1091500", "exe_basename": "other"}) is False
+        # Ambos — casa
+        assert (
+            m.matches(
+                {
+                    "wm_class": "steam_app_1091500",
+                    "exe_basename": "Cyberpunk2077.exe",
+                }
+            )
+            is True
+        )
+
+
+class TestLedsConfig:
+    def test_defaults(self):
+        cfg = LedsConfig()
+        assert cfg.lightbar == (0, 0, 0)
+        assert cfg.player_leds == [False] * 5
+
+    def test_lightbar_byte_invalido(self):
+        with pytest.raises(ValidationError):
+            LedsConfig(lightbar=(300, 0, 0))
+
+    def test_player_leds_tamanho_invalido(self):
+        with pytest.raises(ValidationError):
+            LedsConfig(player_leds=[True, False])
+
+
+class TestTriggerConfig:
+    def test_defaults(self):
+        t = TriggerConfig(mode="Off")
+        assert t.params == []
+
+    def test_params_aceita_inteiros(self):
+        t = TriggerConfig(mode="Galloping", params=[0, 9, 7, 7, 10])
+        assert t.params == [0, 9, 7, 7, 10]
+
+
+class TestProfile:
+    def test_construcao_minima(self):
+        p = Profile(name="test", match=MatchAny())
+        assert p.version == 1
+        assert p.priority == 0
+        assert p.triggers.left.mode == "Off"
+
+    def test_name_vazio_rejeita(self):
+        with pytest.raises(ValidationError):
+            Profile(name="", match=MatchAny())
+
+    def test_name_com_slash_rejeita(self):
+        with pytest.raises(ValidationError):
+            Profile(name="foo/bar", match=MatchAny())
+
+    def test_name_com_dotdot_rejeita(self):
+        with pytest.raises(ValidationError):
+            Profile(name="..", match=MatchAny())
+
+    def test_match_discriminator_any(self):
+        raw = {"name": "fallback", "match": {"type": "any"}}
+        p = Profile.model_validate(raw)
+        assert isinstance(p.match, MatchAny)
+
+    def test_match_discriminator_criteria(self):
+        raw = {
+            "name": "shooter",
+            "match": {
+                "type": "criteria",
+                "window_class": ["Doom"],
+            },
+        }
+        p = Profile.model_validate(raw)
+        assert isinstance(p.match, MatchCriteria)
+        assert p.match.window_class == ["Doom"]
+
+    def test_version_nao_1_rejeita(self):
+        with pytest.raises(ValidationError):
+            Profile.model_validate({"name": "x", "version": 2, "match": {"type": "any"}})
+
+    def test_matches_delega(self):
+        p = Profile(name="driving", match=MatchCriteria(window_title_regex="Forza"))
+        assert p.matches({"wm_name": "Forza Horizon 5"}) is True
+        assert p.matches({"wm_name": "Doom"}) is False
+
+    def test_extra_field_rejeitado(self):
+        with pytest.raises(ValidationError):
+            Profile.model_validate(
+                {"name": "x", "match": {"type": "any"}, "extra_field": 1}
+            )
+
+    def test_roundtrip_json(self):
+        original = Profile(
+            name="shooter",
+            match=MatchCriteria(window_class=["Doom"], window_title_regex="Doom"),
+            priority=10,
+            triggers=TriggersConfig(
+                left=TriggerConfig(mode="Resistance", params=[3, 5]),
+                right=TriggerConfig(mode="Galloping", params=[0, 9, 7, 7, 10]),
+            ),
+            leds=LedsConfig(lightbar=(255, 0, 0), player_leds=[True] * 5),
+            rumble=RumbleConfig(passthrough=False),
+        )
+        dumped = original.model_dump(mode="json")
+        restored = Profile.model_validate(dumped)
+        assert restored == original


### PR DESCRIPTION
## Resumo
Perfis v1 com pydantic (ADR-005) e loader atomico por arquivo.

## Escopo
- `xdg_paths` centraliza paths via platformdirs.
- Schema com `MatchCriteria` (AND/OR V2-8, re.search V2-10, basename V2-9) e `MatchAny` sentinel.
- Discriminated union Match via campo 'type'.
- Loader com FileLock, write atomico, CRUD completo.
- 33 testes novos (151 total).

## Runtime checks
- `ruff check`: pass
- `mypy` strict (25): pass
- `pytest tests/unit -v`: **151 passed**
- `scripts/check_anonymity.sh`: OK

Closes #6