### PR TITLE
W3.2: Profile manager + CLI subcommands

### DIFF
--- a/src/hefesto/cli/app.py
+++ b/src/hefesto/cli/app.py
@@ -26,6 +26,10 @@ daemon_app = typer.Typer(
 )
 app.add_typer(daemon_app, name="daemon")
 
+from hefesto.cli.cmd_profile import app as profile_app  # noqa: E402
+
+app.add_typer(profile_app, name="profile")
+
 
 @app.command()
 def version() -> None:

--- a/src/hefesto/cli/cmd_profile.py
+++ b/src/hefesto/cli/cmd_profile.py
@@ -1,0 +1,181 @@
+"""Subcomando `hefesto profile ...`.
+
+Opera diretamente no diretório de perfis (XDG) sem falar com o daemon
+em execução. Para "ativar" via daemon rodando, W4.2 adicionará uma
+implementação que envia `profile.switch` via IPC; por enquanto, o
+comando `activate` grava a marca de perfil ativo em um arquivo-estado
+local e, se houver hardware/daemon acessível, aplica direto.
+"""
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from hefesto.profiles.loader import (
+    delete_profile,
+    load_all_profiles,
+    load_profile,
+    save_profile,
+)
+from hefesto.profiles.schema import (
+    LedsConfig,
+    Match,
+    MatchAny,
+    MatchCriteria,
+    Profile,
+    TriggerConfig,
+    TriggersConfig,
+)
+
+app = typer.Typer(name="profile", help="Gerencia perfis Hefesto.", no_args_is_help=True)
+console = Console()
+
+
+@app.command("list")
+def cmd_list() -> None:
+    """Lista perfis no diretório XDG."""
+    profiles = load_all_profiles()
+    if not profiles:
+        console.print("[dim]nenhum perfil encontrado[/dim]")
+        return
+
+    table = Table(title="Perfis Hefesto")
+    table.add_column("Nome", style="cyan")
+    table.add_column("Prioridade", justify="right")
+    table.add_column("Match", style="magenta")
+    table.add_column("Triggers", style="yellow")
+
+    for p in profiles:
+        match_desc = _describe_match(p)
+        triggers_desc = f"L={p.triggers.left.mode} R={p.triggers.right.mode}"
+        table.add_row(p.name, str(p.priority), match_desc, triggers_desc)
+
+    console.print(table)
+
+
+@app.command("show")
+def cmd_show(name: str) -> None:
+    """Mostra o JSON bruto de um perfil."""
+    try:
+        profile = load_profile(name)
+    except FileNotFoundError:
+        console.print(f"[red]perfil nao encontrado: {name}[/red]")
+        raise typer.Exit(code=1) from None
+    console.print_json(data=profile.model_dump(mode="json"))
+
+
+@app.command("activate")
+def cmd_activate(name: str) -> None:
+    """Marca perfil como ativo. Aplica direto no controle se hardware disponível."""
+    try:
+        profile = load_profile(name)
+    except FileNotFoundError:
+        console.print(f"[red]perfil nao encontrado: {name}[/red]")
+        raise typer.Exit(code=1) from None
+
+    try:
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+        from hefesto.profiles.manager import ProfileManager
+
+        controller = PyDualSenseController()
+        controller.connect()
+        manager = ProfileManager(controller=controller)
+        manager.apply(profile)
+        controller.disconnect()
+        console.print(f"[green]perfil aplicado no controle: {name}[/green]")
+    except Exception as exc:
+        console.print(
+            f"[yellow]perfil nao aplicado (hardware nao detectado): {exc}[/yellow]"
+        )
+
+    _write_active_marker(name)
+
+
+@app.command("create")
+def cmd_create(
+    name: str = typer.Argument(..., help="Nome do perfil."),
+    priority: int = typer.Option(5, help="Prioridade para resolução de match."),
+    match_regex: str | None = typer.Option(None, help="Regex contra wm_name."),
+    match_class: list[str] = typer.Option(  # noqa: B008
+        default_factory=list, help="Window class (repetir para multiplos)."
+    ),
+    match_exe: list[str] = typer.Option(  # noqa: B008
+        default_factory=list, help="Basename de exe (repetir)."
+    ),
+    fallback: bool = typer.Option(False, "--fallback", help="Perfil com MatchAny (prioridade 0)."),
+) -> None:
+    """Cria um perfil minimo (triggers Off, leds apagados). Edite o JSON depois."""
+    match: Match
+    if fallback:
+        match = MatchAny()
+        priority = 0
+    else:
+        match = MatchCriteria(
+            window_class=match_class or [],
+            window_title_regex=match_regex,
+            process_name=match_exe or [],
+        )
+
+    profile = Profile(
+        name=name,
+        match=match,
+        priority=priority,
+        triggers=TriggersConfig(
+            left=TriggerConfig(mode="Off"),
+            right=TriggerConfig(mode="Off"),
+        ),
+        leds=LedsConfig(lightbar=(0, 0, 0)),
+    )
+    path = save_profile(profile)
+    console.print(f"[green]perfil criado: {path}[/green]")
+
+
+@app.command("delete")
+def cmd_delete(
+    name: str,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Confirma delete."),
+) -> None:
+    """Remove um perfil."""
+    if not yes:
+        typer.confirm(f"Deletar perfil {name!r}?", abort=True)
+    try:
+        delete_profile(name)
+        console.print(f"[green]perfil deletado: {name}[/green]")
+    except FileNotFoundError:
+        console.print(f"[red]perfil nao encontrado: {name}[/red]")
+        raise typer.Exit(code=1) from None
+
+
+def _describe_match(profile: Profile) -> str:
+    m = profile.match
+    if isinstance(m, MatchAny):
+        return "[dim]any[/dim]"
+    parts: list[str] = []
+    if m.window_class:
+        parts.append(f"class={','.join(m.window_class)}")
+    if m.window_title_regex:
+        parts.append(f"title~={m.window_title_regex}")
+    if m.process_name:
+        parts.append(f"exe={','.join(m.process_name)}")
+    return " ".join(parts) if parts else "[dim]vazio[/dim]"
+
+
+def _write_active_marker(name: str) -> None:
+    from hefesto.utils.xdg_paths import config_dir
+
+    marker = config_dir(ensure=True) / "active_profile.txt"
+    marker.write_text(name + "\n", encoding="utf-8")
+
+
+def read_active_marker() -> str | None:
+    from hefesto.utils.xdg_paths import config_dir
+
+    marker = config_dir() / "active_profile.txt"
+    if not marker.exists():
+        return None
+    content = marker.read_text(encoding="utf-8").strip()
+    return content or None
+
+
+__all__ = ["app", "read_active_marker"]

--- a/src/hefesto/profiles/manager.py
+++ b/src/hefesto/profiles/manager.py
@@ -1,0 +1,96 @@
+"""Gerencia perfis em memória e coordena aplicação no controle.
+
+Responsabilidades:
+  - Listar, selecionar e aplicar perfis.
+  - Atualizar o `StateStore` com o nome do perfil ativo.
+  - Chamar `set_trigger` e `apply_led_settings` no controle quando um
+    perfil é ativado.
+
+Auto-switch por janela ativa fica em `hefesto.profiles.autoswitch` (W6.2).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from hefesto.core.controller import IController
+from hefesto.core.led_control import LedSettings, apply_led_settings
+from hefesto.core.trigger_effects import build_from_name
+from hefesto.daemon.state_store import StateStore
+from hefesto.profiles.loader import (
+    delete_profile,
+    load_all_profiles,
+    load_profile,
+    save_profile,
+)
+from hefesto.profiles.schema import LedsConfig, Profile
+from hefesto.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ProfileManager:
+    controller: IController
+    store: StateStore = field(default_factory=StateStore)
+
+    def list_profiles(self) -> list[Profile]:
+        return load_all_profiles()
+
+    def get(self, name: str) -> Profile:
+        return load_profile(name)
+
+    def create(self, profile: Profile) -> None:
+        save_profile(profile)
+        logger.info("profile_created", name=profile.name)
+
+    def delete(self, name: str) -> None:
+        delete_profile(name)
+        active = self.store.active_profile
+        if active == name:
+            self.store.set_active_profile(None)
+        logger.info("profile_deleted", name=name)
+
+    def activate(self, name: str) -> Profile:
+        """Carrega, aplica triggers + LEDs e marca como ativo."""
+        profile = load_profile(name)
+        self.apply(profile)
+        self.store.set_active_profile(profile.name)
+        self.store.bump("profile.activated")
+        logger.info("profile_activated", name=profile.name, priority=profile.priority)
+        return profile
+
+    def apply(self, profile: Profile) -> None:
+        """Aplica triggers e LEDs do perfil no controle (sem marcar como ativo)."""
+        for side, trigger in (("left", profile.triggers.left), ("right", profile.triggers.right)):
+            effect = build_from_name(trigger.mode, trigger.params)
+            self.controller.set_trigger(side, effect)  # type: ignore[arg-type]
+
+        leds = profile.leds
+        settings = _to_led_settings(leds)
+        apply_led_settings(self.controller, settings)
+
+    def select_for_window(self, window_info: dict[str, object]) -> Profile | None:
+        """Escolhe perfil de maior prioridade cujo match case com a janela.
+
+        Se nenhum perfil casa (inclusive fallback), retorna None. Chamado pelo
+        autoswitch em W6.2.
+        """
+        candidates = [p for p in load_all_profiles() if p.matches(dict(window_info))]
+        if not candidates:
+            return None
+        candidates.sort(key=lambda p: p.priority, reverse=True)
+        return candidates[0]
+
+
+def _to_led_settings(leds: LedsConfig) -> LedSettings:
+    player_leds_tuple: tuple[bool, bool, bool, bool, bool] = (
+        leds.player_leds[0],
+        leds.player_leds[1],
+        leds.player_leds[2],
+        leds.player_leds[3],
+        leds.player_leds[4],
+    )
+    return LedSettings(lightbar=leds.lightbar, player_leds=player_leds_tuple)
+
+
+__all__ = ["ProfileManager"]

--- a/tests/unit/test_profile_manager.py
+++ b/tests/unit/test_profile_manager.py
@@ -1,0 +1,147 @@
+"""Testes do ProfileManager."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hefesto.daemon.state_store import StateStore
+from hefesto.profiles import loader as loader_module
+from hefesto.profiles.loader import save_profile
+from hefesto.profiles.manager import ProfileManager
+from hefesto.profiles.schema import (
+    LedsConfig,
+    MatchAny,
+    MatchCriteria,
+    Profile,
+    TriggerConfig,
+    TriggersConfig,
+)
+from tests.fixtures.fake_controller import FakeController
+
+
+@pytest.fixture
+def isolated_profiles_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "profiles"
+    target.mkdir()
+
+    def fake_profiles_dir(ensure: bool = False) -> Path:
+        if ensure:
+            target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    monkeypatch.setattr(loader_module, "profiles_dir", fake_profiles_dir)
+    return target
+
+
+def _mk_profile(name: str, priority: int = 10, **kw) -> Profile:
+    defaults = {
+        "match": MatchCriteria(window_class=[f"{name}_class"]),
+        "priority": priority,
+        "triggers": TriggersConfig(
+            left=TriggerConfig(mode="Off"),
+            right=TriggerConfig(mode="Rigid", params=[5, 200]),
+        ),
+        "leds": LedsConfig(lightbar=(10, 20, 30), player_leds=[True] * 5),
+    }
+    defaults.update(kw)
+    return Profile(name=name, **defaults)
+
+
+def test_activate_aplica_trigger_e_led(isolated_profiles_dir: Path):
+    save_profile(_mk_profile("shooter"))
+    fc = FakeController()
+    fc.connect()
+    store = StateStore()
+    manager = ProfileManager(controller=fc, store=store)
+
+    applied = manager.activate("shooter")
+    assert applied.name == "shooter"
+    assert store.active_profile == "shooter"
+
+    triggers = [c for c in fc.commands if c.kind == "set_trigger"]
+    assert len(triggers) == 2
+    # Right = Rigid (RIGID_B = 5 bits), forces[1] = 200 (force cru)
+    right_call = next(c for c in triggers if c.payload[0] == "right")
+    assert right_call.payload[1].forces == (5, 200, 0, 0, 0, 0, 0)
+
+    leds = [c for c in fc.commands if c.kind == "set_led"]
+    assert len(leds) == 1
+    assert leds[0].payload == (10, 20, 30)
+
+
+def test_list_profiles_ordenado(isolated_profiles_dir: Path):
+    save_profile(_mk_profile("driving"))
+    save_profile(_mk_profile("shooter"))
+    save_profile(_mk_profile("bow"))
+    fc = FakeController()
+    fc.connect()
+    manager = ProfileManager(controller=fc)
+    names = [p.name for p in manager.list_profiles()]
+    assert names == ["bow", "driving", "shooter"]
+
+
+def test_select_for_window_retorna_maior_prioridade(isolated_profiles_dir: Path):
+    save_profile(
+        _mk_profile("driving", priority=10, match=MatchCriteria(window_class=["Forza"]))
+    )
+    save_profile(
+        _mk_profile(
+            "shooter",
+            priority=20,
+            match=MatchCriteria(window_class=["Forza"]),
+        )
+    )
+    save_profile(Profile(name="fallback", match=MatchAny(), priority=0))
+
+    fc = FakeController()
+    fc.connect()
+    manager = ProfileManager(controller=fc)
+    picked = manager.select_for_window({"wm_class": "Forza"})
+    assert picked is not None
+    assert picked.name == "shooter"  # maior priority
+
+
+def test_select_for_window_fallback(isolated_profiles_dir: Path):
+    save_profile(
+        _mk_profile("shooter", match=MatchCriteria(window_class=["DoomEternal"]))
+    )
+    save_profile(Profile(name="fallback", match=MatchAny(), priority=0))
+
+    fc = FakeController()
+    fc.connect()
+    manager = ProfileManager(controller=fc)
+    picked = manager.select_for_window({"wm_class": "Inkscape"})
+    assert picked is not None
+    assert picked.name == "fallback"
+
+
+def test_select_for_window_sem_match_sem_fallback(isolated_profiles_dir: Path):
+    save_profile(_mk_profile("shooter", match=MatchCriteria(window_class=["X"])))
+
+    fc = FakeController()
+    fc.connect()
+    manager = ProfileManager(controller=fc)
+    picked = manager.select_for_window({"wm_class": "Nada"})
+    assert picked is None
+
+
+def test_delete_do_ativo_reseta_active_profile(isolated_profiles_dir: Path):
+    save_profile(_mk_profile("tmp"))
+    fc = FakeController()
+    fc.connect()
+    store = StateStore()
+    manager = ProfileManager(controller=fc, store=store)
+    manager.activate("tmp")
+    assert store.active_profile == "tmp"
+    manager.delete("tmp")
+    assert store.active_profile is None
+
+
+def test_create_persiste_no_disco(isolated_profiles_dir: Path):
+    fc = FakeController()
+    fc.connect()
+    manager = ProfileManager(controller=fc)
+    profile = _mk_profile("new_one")
+    manager.create(profile)
+    assert (isolated_profiles_dir / "new_one.json").exists()


### PR DESCRIPTION
## Resumo
ProfileManager + subcomandos `hefesto profile list/show/activate/create/delete`.

## Escopo
- `ProfileManager` orquestra activate/apply/select_for_window (maior prioridade).
- CLI com rich table, json pretty, confirmação de delete.
- MatchAny via `--fallback` automaticamente zera priority.
- 7 testes novos (158 total).

## Runtime checks
- `ruff check`: pass
- `mypy` strict (27): pass
- `pytest tests/unit -v`: **158 passed**
- `scripts/check_anonymity.sh`: OK

Closes #7