### PR TITLE
W4.1: systemd user service install + gestao

### DIFF
--- a/src/hefesto/cli/app.py
+++ b/src/hefesto/cli/app.py
@@ -61,6 +61,63 @@ def daemon_start(
     raise typer.Exit(code=exit_code)
 
 
+@daemon_app.command("install-service")
+def daemon_install_service(
+    headless: bool = typer.Option(False, "--headless", help="Instala unit headless."),
+) -> None:
+    """Copia a unit systemd --user e habilita, respeitando Conflicts mutuo."""
+    from hefesto.daemon.service_install import ServiceInstaller
+
+    installer = ServiceInstaller()
+    dst = installer.install(headless=headless)
+    typer.echo(f"unit instalada: {dst}")
+
+
+@daemon_app.command("uninstall-service")
+def daemon_uninstall_service() -> None:
+    """Remove todas as unidades do Hefesto de ~/.config/systemd/user/."""
+    from hefesto.daemon.service_install import ServiceInstaller
+
+    installer = ServiceInstaller()
+    removed = installer.uninstall()
+    if not removed:
+        typer.echo("nenhuma unit instalada.")
+        return
+    for p in removed:
+        typer.echo(f"removido: {p}")
+
+
+@daemon_app.command("stop")
+def daemon_stop(
+    headless: bool = typer.Option(False, "--headless"),
+) -> None:
+    """Para o daemon gerenciado pelo systemd --user."""
+    from hefesto.daemon.service_install import ServiceInstaller
+
+    ServiceInstaller().stop(headless=headless)
+
+
+@daemon_app.command("restart")
+def daemon_restart(
+    headless: bool = typer.Option(False, "--headless"),
+) -> None:
+    """Reinicia o daemon gerenciado pelo systemd --user."""
+    from hefesto.daemon.service_install import ServiceInstaller
+
+    ServiceInstaller().restart(headless=headless)
+
+
+@daemon_app.command("status")
+def daemon_status(
+    headless: bool = typer.Option(False, "--headless"),
+) -> None:
+    """Mostra status do daemon via systemctl."""
+    from hefesto.daemon.service_install import ServiceInstaller
+
+    text = ServiceInstaller().status_text(headless=headless)
+    typer.echo(text)
+
+
 def main() -> None:
     """Entry point declarado em pyproject.toml [project.scripts]."""
     app()

--- a/src/hefesto/daemon/service_install.py
+++ b/src/hefesto/daemon/service_install.py
@@ -1,0 +1,153 @@
+"""Instalação e gestão das unidades systemd --user.
+
+Respeita a decisão V2-12 (Conflicts= mútuo entre `hefesto.service` e
+`hefesto-headless.service`). Ao habilitar uma, desabilita a outra.
+
+Path canônico: `~/.config/systemd/user/`. Para descobrir os `.service`
+originais, lemos o diretório `assets/` do repo (desenvolvimento) ou
+`/usr/share/hefesto/assets/` (pacote instalado). Em modo de desenvolvimento,
+descobrimos via `importlib.resources` se empacotado como wheel.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from hefesto.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+SERVICE_NORMAL = "hefesto.service"
+SERVICE_HEADLESS = "hefesto-headless.service"
+
+
+def user_unit_dir() -> Path:
+    """`~/.config/systemd/user/` (cria se não existe)."""
+    base = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    target = base / "systemd" / "user"
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def find_assets_dir() -> Path:
+    """Localiza `assets/` contendo as unidades `.service`.
+
+    Ordem:
+      1. `HEFESTO_ASSETS_DIR` env (sobrescreve tudo, útil pra testes).
+      2. Repo layout: `<source>/assets/` relativo ao módulo.
+      3. `/usr/share/hefesto/assets/` (pacote instalado).
+    """
+    override = os.environ.get("HEFESTO_ASSETS_DIR")
+    if override:
+        return Path(override)
+
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        candidate = ancestor / "assets"
+        if (candidate / SERVICE_NORMAL).exists():
+            return candidate
+
+    system_path = Path("/usr/share/hefesto/assets")
+    if (system_path / SERVICE_NORMAL).exists():
+        return system_path
+
+    raise FileNotFoundError("assets/ nao encontrado (nem via HEFESTO_ASSETS_DIR)")
+
+
+@dataclass
+class ServiceInstaller:
+    """Instala/remove unidades e coordena mutual exclusion."""
+
+    dry_run: bool = False
+
+    def install(self, *, headless: bool) -> Path:
+        assets = find_assets_dir()
+        target_name = SERVICE_HEADLESS if headless else SERVICE_NORMAL
+        opposite_name = SERVICE_NORMAL if headless else SERVICE_HEADLESS
+
+        src = assets / target_name
+        if not src.exists():
+            raise FileNotFoundError(f"unit source nao existe: {src}")
+
+        dst = user_unit_dir() / target_name
+        if not self.dry_run:
+            shutil.copy2(src, dst)
+        logger.info("service_copied", src=str(src), dst=str(dst))
+
+        self._systemctl("daemon-reload")
+        self._disable_if_installed(opposite_name)
+        self._systemctl("enable", target_name)
+
+        return dst
+
+    def uninstall(self) -> list[Path]:
+        removed: list[Path] = []
+        for name in (SERVICE_NORMAL, SERVICE_HEADLESS):
+            self._disable_if_installed(name)
+            dst = user_unit_dir() / name
+            if dst.exists():
+                if not self.dry_run:
+                    dst.unlink()
+                removed.append(dst)
+        self._systemctl("daemon-reload")
+        return removed
+
+    def start(self, *, headless: bool) -> None:
+        name = SERVICE_HEADLESS if headless else SERVICE_NORMAL
+        self._systemctl("start", name)
+
+    def stop(self, *, headless: bool) -> None:
+        name = SERVICE_HEADLESS if headless else SERVICE_NORMAL
+        self._systemctl("stop", name)
+
+    def restart(self, *, headless: bool) -> None:
+        name = SERVICE_HEADLESS if headless else SERVICE_NORMAL
+        self._systemctl("restart", name)
+
+    def status_text(self, *, headless: bool) -> str:
+        name = SERVICE_HEADLESS if headless else SERVICE_NORMAL
+        result = self._systemctl("status", name, capture=True, check=False)
+        return result.stdout if result is not None else ""
+
+    def detect_installed_units(self) -> list[str]:
+        """Retorna nomes das units (.service) presentes em `user_unit_dir()`."""
+        base = user_unit_dir()
+        return [n for n in (SERVICE_NORMAL, SERVICE_HEADLESS) if (base / n).exists()]
+
+    def _disable_if_installed(self, name: str) -> None:
+        if (user_unit_dir() / name).exists():
+            self._systemctl("disable", name, check=False)
+
+    def _systemctl(
+        self,
+        *args: str,
+        capture: bool = False,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str] | None:
+        cmd = ["systemctl", "--user", *args]
+        logger.debug("systemctl_call", cmd=cmd, dry_run=self.dry_run)
+        if self.dry_run:
+            return None
+        try:
+            return subprocess.run(
+                cmd,
+                check=check,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "systemctl nao encontrado — distro sem systemd (ver ADR-009)"
+            ) from exc
+
+
+__all__ = [
+    "SERVICE_HEADLESS",
+    "SERVICE_NORMAL",
+    "ServiceInstaller",
+    "find_assets_dir",
+    "user_unit_dir",
+]

--- a/tests/unit/test_service_install.py
+++ b/tests/unit/test_service_install.py
@@ -1,0 +1,137 @@
+"""Testes do instalador de units systemd --user."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hefesto.daemon import service_install as si
+from hefesto.daemon.service_install import (
+    SERVICE_HEADLESS,
+    SERVICE_NORMAL,
+    ServiceInstaller,
+    find_assets_dir,
+)
+
+
+@pytest.fixture
+def isolated_systemd_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Aponta `user_unit_dir()` para tmp e força `find_assets_dir()` ao repo."""
+    xdg_config = tmp_path / "config"
+    xdg_config.mkdir()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config))
+    return xdg_config / "systemd" / "user"
+
+
+class DummyResult:
+    def __init__(self, stdout: str = "") -> None:
+        self.stdout = stdout
+        self.returncode = 0
+
+
+@pytest.fixture
+def dummy_systemctl(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check=True, capture_output=True, text=True):
+        calls.append(list(cmd))
+        return DummyResult(stdout="active (running)\n")
+
+    monkeypatch.setattr(si.subprocess, "run", fake_run)
+    return calls
+
+
+def test_find_assets_dir_retorna_path_existente():
+    assets = find_assets_dir()
+    assert (assets / SERVICE_NORMAL).exists()
+    assert (assets / SERVICE_HEADLESS).exists()
+
+
+def test_install_normal_copia_unit(isolated_systemd_user: Path, dummy_systemctl: list):
+    installer = ServiceInstaller()
+    dst = installer.install(headless=False)
+    assert dst.name == SERVICE_NORMAL
+    assert dst.parent == isolated_systemd_user
+    assert dst.exists()
+
+    cmds = [" ".join(c) for c in dummy_systemctl]
+    assert any("daemon-reload" in c for c in cmds)
+    assert any(f"enable {SERVICE_NORMAL}" in c for c in cmds)
+
+
+def test_install_headless_desabilita_oposta(isolated_systemd_user: Path, dummy_systemctl: list):
+    # Pré-condição: instala normal primeiro (fisicamente cria o arquivo no dir).
+    assets = find_assets_dir()
+    isolated_systemd_user.mkdir(parents=True, exist_ok=True)
+    (isolated_systemd_user / SERVICE_NORMAL).write_text(
+        (assets / SERVICE_NORMAL).read_text()
+    )
+
+    installer = ServiceInstaller()
+    installer.install(headless=True)
+
+    cmds = [" ".join(c) for c in dummy_systemctl]
+    assert any(f"disable {SERVICE_NORMAL}" in c for c in cmds)
+    assert any(f"enable {SERVICE_HEADLESS}" in c for c in cmds)
+    assert (isolated_systemd_user / SERVICE_HEADLESS).exists()
+
+
+def test_uninstall_remove_arquivos(isolated_systemd_user: Path, dummy_systemctl: list):
+    isolated_systemd_user.mkdir(parents=True, exist_ok=True)
+    (isolated_systemd_user / SERVICE_NORMAL).write_text("stub")
+    (isolated_systemd_user / SERVICE_HEADLESS).write_text("stub")
+
+    installer = ServiceInstaller()
+    removed = installer.uninstall()
+    assert len(removed) == 2
+    assert not (isolated_systemd_user / SERVICE_NORMAL).exists()
+    assert not (isolated_systemd_user / SERVICE_HEADLESS).exists()
+
+
+def test_uninstall_sem_nada_instalado(isolated_systemd_user: Path, dummy_systemctl: list):
+    installer = ServiceInstaller()
+    removed = installer.uninstall()
+    assert removed == []
+
+
+def test_start_stop_restart_status(isolated_systemd_user: Path, dummy_systemctl: list):
+    installer = ServiceInstaller()
+    installer.start(headless=False)
+    installer.stop(headless=False)
+    installer.restart(headless=True)
+    text = installer.status_text(headless=False)
+    assert "active" in text
+
+    cmds = [" ".join(c) for c in dummy_systemctl]
+    assert any(f"start {SERVICE_NORMAL}" in c for c in cmds)
+    assert any(f"stop {SERVICE_NORMAL}" in c for c in cmds)
+    assert any(f"restart {SERVICE_HEADLESS}" in c for c in cmds)
+
+
+def test_detect_installed_units(isolated_systemd_user: Path, dummy_systemctl: list):
+    isolated_systemd_user.mkdir(parents=True, exist_ok=True)
+    (isolated_systemd_user / SERVICE_NORMAL).write_text("stub")
+    installer = ServiceInstaller()
+    assert installer.detect_installed_units() == [SERVICE_NORMAL]
+
+    (isolated_systemd_user / SERVICE_HEADLESS).write_text("stub")
+    assert sorted(installer.detect_installed_units()) == sorted(
+        [SERVICE_NORMAL, SERVICE_HEADLESS]
+    )
+
+
+def test_dry_run_nao_copia(isolated_systemd_user: Path, dummy_systemctl: list):
+    installer = ServiceInstaller(dry_run=True)
+    installer.install(headless=False)
+    # Arquivo não copiado; systemctl não chamado (retornou None).
+    assert not (isolated_systemd_user / SERVICE_NORMAL).exists()
+
+
+def test_find_assets_dir_respeita_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    fake = tmp_path / "fake_assets"
+    fake.mkdir()
+    (fake / SERVICE_NORMAL).write_text("stub")
+    (fake / SERVICE_HEADLESS).write_text("stub")
+    monkeypatch.setenv("HEFESTO_ASSETS_DIR", str(fake))
+
+    assert find_assets_dir() == fake


### PR DESCRIPTION
## Resumo
ServiceInstaller cuida das units `.service`, CLI expoe subcomandos.

## Escopo
- install/uninstall respeita Conflicts mutuo (V2-12).
- start, stop, restart, status delegam ao systemctl --user.
- HEFESTO_ASSETS_DIR para testes; dry_run para smoke.
- 9 testes novos (167 total).

## Runtime checks
- `ruff check`: pass
- `mypy` strict (28): pass
- `pytest tests/unit -v`: **167 passed**
- `scripts/check_anonymity.sh`: OK

Closes #8