### PR TITLE
W4.2: IPC Unix socket JSON-RPC 2.0

### DIFF
--- a/src/hefesto/cli/ipc_client.py
+++ b/src/hefesto/cli/ipc_client.py
@@ -1,0 +1,75 @@
+"""Cliente JSON-RPC 2.0 sobre Unix socket para falar com o daemon.
+
+Uso típico de CLI/TUI:
+    async with IpcClient.connect() as client:
+        status = await client.call("daemon.status")
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hefesto.daemon.ipc_server import PROTOCOL_VERSION
+from hefesto.utils.xdg_paths import ipc_socket_path
+
+
+class IpcError(RuntimeError):
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(f"[{code}] {message}")
+        self.code = code
+        self.message = message
+
+
+@dataclass
+class IpcClient:
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+    _next_id: int = 0
+
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def connect(
+        cls, socket_path: Path | None = None
+    ) -> AsyncIterator[IpcClient]:
+        path = socket_path or ipc_socket_path()
+        reader, writer = await asyncio.open_unix_connection(str(path))
+        client = cls(reader=reader, writer=writer)
+        try:
+            yield client
+        finally:
+            await client.close()
+
+    async def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self.writer.close()
+            await self.writer.wait_closed()
+
+    async def call(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        self._next_id += 1
+        request = {
+            "jsonrpc": PROTOCOL_VERSION,
+            "id": self._next_id,
+            "method": method,
+            "params": params or {},
+        }
+        payload = json.dumps(request, ensure_ascii=False).encode("utf-8") + b"\n"
+        self.writer.write(payload)
+        await self.writer.drain()
+
+        raw = await self.reader.readline()
+        if not raw:
+            raise IpcError(-1, "conexao fechada pelo servidor antes da resposta")
+
+        response = json.loads(raw.decode("utf-8"))
+        if "error" in response:
+            err = response["error"]
+            raise IpcError(err["code"], err["message"])
+        return response.get("result")
+
+
+__all__ = ["IpcClient", "IpcError"]

--- a/src/hefesto/daemon/ipc_server.py
+++ b/src/hefesto/daemon/ipc_server.py
@@ -1,0 +1,256 @@
+"""IPC Unix socket JSON-RPC 2.0 (V2-3, ADR-005, `docs/protocol/ipc-unix-socket.md`).
+
+NDJSON UTF-8, uma mensagem por linha. Suporta 8 métodos v1:
+
+    profile.switch    {name: str} -> {active_profile: str}
+    profile.list      {}          -> {profiles: [{name, priority, match_type}]}
+    trigger.set       {side, mode, params} -> {status}
+    trigger.reset     {side?}               -> {status}
+    led.set           {rgb}                 -> {status}
+    daemon.status     {}          -> {connected, transport, active_profile, battery_pct}
+    controller.list   {}          -> {controllers: [{connected, transport}]}
+    daemon.reload     {}          -> {status}
+
+Erros seguem JSON-RPC 2.0; códigos do domínio em `docs/protocol/ipc-unix-socket.md`.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hefesto.core.controller import IController
+from hefesto.core.trigger_effects import build_from_name
+from hefesto.core.trigger_effects import off as trigger_off
+from hefesto.daemon.state_store import StateStore
+from hefesto.profiles.manager import ProfileManager
+from hefesto.profiles.schema import MatchAny
+from hefesto.utils.logging_config import get_logger
+from hefesto.utils.xdg_paths import ipc_socket_path
+
+logger = get_logger(__name__)
+
+PROTOCOL_VERSION = "2.0"
+
+CODE_CONTROLLER_DISCONNECTED = -32001
+CODE_PROFILE_NOT_FOUND = -32002
+CODE_INVALID_PARAMS = -32003
+CODE_CONTROLLER_LOST = -32004
+CODE_INTERNAL = -32603
+CODE_METHOD_NOT_FOUND = -32601
+CODE_PARSE_ERROR = -32700
+
+
+Handler = Callable[[dict[str, Any]], Awaitable[Any]]
+
+
+@dataclass
+class IpcServer:
+    controller: IController
+    store: StateStore
+    profile_manager: ProfileManager
+    socket_path: Path = field(default_factory=ipc_socket_path)
+
+    _handlers: dict[str, Handler] = field(default_factory=dict)
+    _server: asyncio.base_events.Server | None = None
+
+    def __post_init__(self) -> None:
+        self._handlers = {
+            "profile.switch": self._handle_profile_switch,
+            "profile.list": self._handle_profile_list,
+            "trigger.set": self._handle_trigger_set,
+            "trigger.reset": self._handle_trigger_reset,
+            "led.set": self._handle_led_set,
+            "daemon.status": self._handle_daemon_status,
+            "controller.list": self._handle_controller_list,
+            "daemon.reload": self._handle_daemon_reload,
+        }
+
+    async def start(self) -> None:
+        """Inicia o servidor. Remove socket órfão se existir."""
+        self.socket_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+
+        self._server = await asyncio.start_unix_server(
+            self._serve_client, path=str(self.socket_path)
+        )
+        os.chmod(self.socket_path, 0o600)
+        logger.info("ipc_server_listening", path=str(self.socket_path))
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            with contextlib.suppress(Exception):
+                await self._server.wait_closed()
+            self._server = None
+        with contextlib.suppress(FileNotFoundError):
+            self.socket_path.unlink()
+
+    async def _serve_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            while not reader.at_eof():
+                raw = await reader.readline()
+                if not raw:
+                    break
+                response = await self._dispatch(raw)
+                if response is not None:
+                    writer.write(response + b"\n")
+                    await writer.drain()
+        except Exception as exc:
+            logger.warning("ipc_client_error", err=str(exc))
+        finally:
+            with contextlib.suppress(Exception):
+                writer.close()
+                await writer.wait_closed()
+
+    async def _dispatch(self, raw: bytes) -> bytes | None:
+        try:
+            payload = json.loads(raw.decode("utf-8").strip() or "null")
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return _json_rpc_error(None, CODE_PARSE_ERROR, f"parse: {exc}")
+        if not isinstance(payload, dict):
+            return _json_rpc_error(None, CODE_PARSE_ERROR, "payload nao eh objeto")
+
+        req_id = payload.get("id")
+        method = payload.get("method")
+        params = payload.get("params") or {}
+
+        if not isinstance(method, str):
+            return _json_rpc_error(req_id, CODE_PARSE_ERROR, "method ausente")
+        if not isinstance(params, dict):
+            return _json_rpc_error(req_id, CODE_INVALID_PARAMS, "params nao eh objeto")
+
+        handler = self._handlers.get(method)
+        if handler is None:
+            return _json_rpc_error(req_id, CODE_METHOD_NOT_FOUND, f"metodo desconhecido: {method}")
+
+        try:
+            result = await handler(params)
+        except FileNotFoundError as exc:
+            return _json_rpc_error(req_id, CODE_PROFILE_NOT_FOUND, str(exc))
+        except ValueError as exc:
+            return _json_rpc_error(req_id, CODE_INVALID_PARAMS, str(exc))
+        except Exception as exc:
+            logger.exception("ipc_handler_error", method=method)
+            return _json_rpc_error(req_id, CODE_INTERNAL, str(exc))
+
+        if req_id is None:
+            return None
+        return _json_rpc_result(req_id, result)
+
+    # --- handlers --------------------------------------------------------
+
+    async def _handle_profile_switch(self, params: dict[str, Any]) -> dict[str, Any]:
+        name = params.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("profile.switch exige 'name' string")
+        profile = self.profile_manager.activate(name)
+        return {"active_profile": profile.name}
+
+    async def _handle_profile_list(self, params: dict[str, Any]) -> dict[str, Any]:
+        profiles = self.profile_manager.list_profiles()
+        return {
+            "profiles": [
+                {
+                    "name": p.name,
+                    "priority": p.priority,
+                    "match_type": "any" if isinstance(p.match, MatchAny) else "criteria",
+                }
+                for p in profiles
+            ]
+        }
+
+    async def _handle_trigger_set(self, params: dict[str, Any]) -> dict[str, Any]:
+        side = params.get("side")
+        mode = params.get("mode")
+        trigger_params = params.get("params", [])
+        if side not in ("left", "right"):
+            raise ValueError("trigger.set: side precisa ser 'left' ou 'right'")
+        if not isinstance(mode, str):
+            raise ValueError("trigger.set: mode precisa ser string")
+        if not isinstance(trigger_params, list):
+            raise ValueError("trigger.set: params precisa ser lista")
+        effect = build_from_name(mode, trigger_params)
+        self.controller.set_trigger(side, effect)
+        return {"status": "ok"}
+
+    async def _handle_trigger_reset(self, params: dict[str, Any]) -> dict[str, Any]:
+        target = params.get("side", "both")
+        if target not in ("left", "right", "both"):
+            raise ValueError("trigger.reset: side deve ser left|right|both")
+        if target in ("left", "both"):
+            self.controller.set_trigger("left", trigger_off())
+        if target in ("right", "both"):
+            self.controller.set_trigger("right", trigger_off())
+        return {"status": "ok"}
+
+    async def _handle_led_set(self, params: dict[str, Any]) -> dict[str, Any]:
+        rgb = params.get("rgb")
+        if not isinstance(rgb, list) or len(rgb) != 3:
+            raise ValueError("led.set: rgb precisa ser lista com 3 inteiros")
+        for idx, v in enumerate(rgb):
+            if not isinstance(v, int) or not (0 <= v <= 255):
+                raise ValueError(f"led.set: rgb[{idx}] fora de byte")
+        self.controller.set_led((rgb[0], rgb[1], rgb[2]))
+        return {"status": "ok"}
+
+    async def _handle_daemon_status(self, params: dict[str, Any]) -> dict[str, Any]:
+        snap = self.store.snapshot()
+        controller = snap.controller
+        return {
+            "connected": bool(controller and controller.connected),
+            "transport": controller.transport if controller else None,
+            "active_profile": snap.active_profile,
+            "battery_pct": controller.battery_pct if controller else None,
+        }
+
+    async def _handle_controller_list(self, params: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "controllers": [
+                {
+                    "connected": self.controller.is_connected(),
+                    "transport": self.controller.get_transport()
+                    if self.controller.is_connected()
+                    else None,
+                }
+            ]
+        }
+
+    async def _handle_daemon_reload(self, params: dict[str, Any]) -> dict[str, Any]:
+        # Placeholder: reload de config chega em W4.1+ quando tivermos daemon.toml real.
+        return {"status": "ok", "reloaded": True}
+
+
+def _json_rpc_result(req_id: Any, result: Any) -> bytes:
+    payload = {"jsonrpc": PROTOCOL_VERSION, "id": req_id, "result": result}
+    return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
+def _json_rpc_error(req_id: Any, code: int, message: str) -> bytes:
+    payload = {
+        "jsonrpc": PROTOCOL_VERSION,
+        "id": req_id,
+        "error": {"code": code, "message": message},
+    }
+    return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
+__all__ = [
+    "CODE_CONTROLLER_DISCONNECTED",
+    "CODE_CONTROLLER_LOST",
+    "CODE_INTERNAL",
+    "CODE_INVALID_PARAMS",
+    "CODE_METHOD_NOT_FOUND",
+    "CODE_PARSE_ERROR",
+    "CODE_PROFILE_NOT_FOUND",
+    "PROTOCOL_VERSION",
+    "IpcServer",
+]

--- a/src/hefesto/daemon/lifecycle.py
+++ b/src/hefesto/daemon/lifecycle.py
@@ -23,6 +23,7 @@ from typing import Any
 from hefesto.core.controller import IController
 from hefesto.core.events import EventBus, EventTopic
 from hefesto.daemon.state_store import StateStore
+from hefesto.profiles.manager import ProfileManager
 from hefesto.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -38,6 +39,7 @@ class DaemonConfig:
     poll_hz: int = DEFAULT_POLL_HZ
     auto_reconnect: bool = True
     reconnect_backoff_sec: float = 2.0
+    ipc_enabled: bool = True
 
 
 class BatteryDebouncer:
@@ -79,6 +81,7 @@ class Daemon:
     _stop_event: asyncio.Event | None = None
     _executor: ThreadPoolExecutor | None = None
     _tasks: list[asyncio.Task[Any]] = field(default_factory=list)
+    _ipc_server: Any = None
 
     async def run(self) -> None:
         """Entry point: start tasks, wait until stop, shutdown."""
@@ -92,6 +95,8 @@ class Daemon:
         try:
             await self._connect_with_retry()
             self._tasks = [asyncio.create_task(self._poll_loop(), name="poll_loop")]
+            if self.config.ipc_enabled:
+                await self._start_ipc()
             await self._stop_event.wait()
         finally:
             await self._shutdown()
@@ -158,8 +163,23 @@ class Daemon:
         await asyncio.sleep(self.config.reconnect_backoff_sec)
         await self._connect_with_retry()
 
+    async def _start_ipc(self) -> None:
+        from hefesto.daemon.ipc_server import IpcServer
+
+        manager = ProfileManager(controller=self.controller, store=self.store)
+        self._ipc_server = IpcServer(
+            controller=self.controller,
+            store=self.store,
+            profile_manager=manager,
+        )
+        await self._ipc_server.start()
+
     async def _shutdown(self) -> None:
         logger.info("daemon_shutting_down")
+        if self._ipc_server is not None:
+            with contextlib.suppress(Exception):
+                await self._ipc_server.stop()
+            self._ipc_server = None
         for task in self._tasks:
             task.cancel()
         for task in self._tasks:

--- a/tests/unit/test_ipc_server.py
+++ b/tests/unit/test_ipc_server.py
@@ -1,0 +1,216 @@
+"""Testes do IPC server JSON-RPC 2.0."""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from hefesto.cli.ipc_client import IpcClient, IpcError
+from hefesto.core.controller import ControllerState
+from hefesto.daemon.ipc_server import (
+    CODE_INVALID_PARAMS,
+    CODE_METHOD_NOT_FOUND,
+    CODE_PROFILE_NOT_FOUND,
+    IpcServer,
+)
+from hefesto.daemon.state_store import StateStore
+from hefesto.profiles import loader as loader_module
+from hefesto.profiles.loader import save_profile
+from hefesto.profiles.manager import ProfileManager
+from hefesto.profiles.schema import (
+    LedsConfig,
+    MatchAny,
+    MatchCriteria,
+    Profile,
+    TriggerConfig,
+    TriggersConfig,
+)
+from tests.fixtures.fake_controller import FakeController
+
+
+@pytest.fixture
+def isolated_profiles_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "profiles"
+    target.mkdir()
+
+    def fake_profiles_dir(ensure: bool = False) -> Path:
+        if ensure:
+            target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    monkeypatch.setattr(loader_module, "profiles_dir", fake_profiles_dir)
+    return target
+
+
+@pytest.fixture
+async def running_server(tmp_path: Path, isolated_profiles_dir: Path):
+    """IpcServer no ar em socket de tmp_path. Yields (server, socket_path, fake)."""
+    fc = FakeController(transport="usb")
+    fc.connect()
+    store = StateStore()
+    store.update_controller_state(
+        ControllerState(
+            battery_pct=75, l2_raw=0, r2_raw=0, connected=True, transport="usb"
+        )
+    )
+    manager = ProfileManager(controller=fc, store=store)
+
+    save_profile(Profile(name="fallback", match=MatchAny(), priority=0))
+    save_profile(
+        Profile(
+            name="shooter",
+            match=MatchCriteria(window_class=["Doom"]),
+            priority=10,
+            triggers=TriggersConfig(
+                left=TriggerConfig(mode="Off"),
+                right=TriggerConfig(mode="Rigid", params=[5, 200]),
+            ),
+            leds=LedsConfig(lightbar=(255, 0, 0)),
+        )
+    )
+
+    socket_path = tmp_path / "hefesto.sock"
+    server = IpcServer(
+        controller=fc, store=store, profile_manager=manager, socket_path=socket_path
+    )
+    await server.start()
+    try:
+        yield server, socket_path, fc
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_profile_list_retorna_todos(running_server):
+    _server, socket_path, _ = running_server
+    async with IpcClient.connect(socket_path) as client:
+        result = await client.call("profile.list")
+    names = sorted(p["name"] for p in result["profiles"])
+    assert names == ["fallback", "shooter"]
+
+
+@pytest.mark.asyncio
+async def test_profile_switch_ativa_e_retorna_nome(running_server):
+    server, socket_path, fc = running_server
+    async with IpcClient.connect(socket_path) as client:
+        result = await client.call("profile.switch", {"name": "shooter"})
+    assert result == {"active_profile": "shooter"}
+    assert server.store.active_profile == "shooter"
+
+    triggers = [c for c in fc.commands if c.kind == "set_trigger"]
+    assert len(triggers) == 2
+    leds = [c for c in fc.commands if c.kind == "set_led"]
+    assert leds[-1].payload == (255, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_profile_switch_inexistente(running_server):
+    _server, socket_path, _ = running_server
+    async with IpcClient.connect(socket_path) as client:
+        with pytest.raises(IpcError) as exc_info:
+            await client.call("profile.switch", {"name": "ghost"})
+    assert exc_info.value.code == CODE_PROFILE_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_trigger_set_e_reset(running_server):
+    _server, socket_path, fc = running_server
+    async with IpcClient.connect(socket_path) as client:
+        assert await client.call(
+            "trigger.set",
+            {"side": "right", "mode": "Rigid", "params": [5, 200]},
+        ) == {"status": "ok"}
+
+        assert await client.call("trigger.reset", {"side": "right"}) == {"status": "ok"}
+        assert await client.call("trigger.reset") == {"status": "ok"}  # both
+
+    triggers = [c for c in fc.commands if c.kind == "set_trigger"]
+    assert len(triggers) >= 4  # 1 set + 1 reset + 2 reset both
+
+
+@pytest.mark.asyncio
+async def test_trigger_set_side_invalido(running_server):
+    _server, socket_path, _ = running_server
+    async with IpcClient.connect(socket_path) as client:
+        with pytest.raises(IpcError) as exc:
+            await client.call("trigger.set", {"side": "middle", "mode": "Off", "params": []})
+    assert exc.value.code == CODE_INVALID_PARAMS
+
+
+@pytest.mark.asyncio
+async def test_led_set(running_server):
+    _server, socket_path, fc = running_server
+    async with IpcClient.connect(socket_path) as client:
+        await client.call("led.set", {"rgb": [255, 128, 0]})
+    leds = [c for c in fc.commands if c.kind == "set_led"]
+    assert leds[-1].payload == (255, 128, 0)
+
+
+@pytest.mark.asyncio
+async def test_led_set_fora_de_byte(running_server):
+    _server, socket_path, _ = running_server
+    async with IpcClient.connect(socket_path) as client:
+        with pytest.raises(IpcError) as exc:
+            await client.call("led.set", {"rgb": [300, 0, 0]})
+    assert exc.value.code == CODE_INVALID_PARAMS
+
+
+@pytest.mark.asyncio
+async def test_daemon_status(running_server):
+    _server, socket_path, _ = running_server
+    async with IpcClient.connect(socket_path) as client:
+        result = await client.call("daemon.status")
+    assert result["connected"] is True
+    assert result["transport"] == "usb"
+    assert result["battery_pct"] == 75
+
+
+@pytest.mark.asyncio
+async def test_controller_list(running_server):
+    _server, socket_path, _ = running_server
+    async with IpcClient.connect(socket_path) as client:
+        result = await client.call("controller.list")
+    assert result["controllers"][0]["connected"] is True
+
+
+@pytest.mark.asyncio
+async def test_daemon_reload(running_server):
+    _server, socket_path, _ = running_server
+    async with IpcClient.connect(socket_path) as client:
+        result = await client.call("daemon.reload")
+    assert result["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_metodo_desconhecido_retorna_erro(running_server):
+    _server, socket_path, _ = running_server
+    async with IpcClient.connect(socket_path) as client:
+        with pytest.raises(IpcError) as exc:
+            await client.call("nao.existe")
+    assert exc.value.code == CODE_METHOD_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_json_malformado_retorna_parse_error(running_server):
+    _server, socket_path, _ = running_server
+    reader, writer = await asyncio.open_unix_connection(str(socket_path))
+    try:
+        writer.write(b"{isto nao e json}\n")
+        await writer.drain()
+        raw = await reader.readline()
+    finally:
+        writer.close()
+        await writer.wait_closed()
+    response = json.loads(raw.decode("utf-8"))
+    assert "error" in response
+
+
+@pytest.mark.asyncio
+async def test_socket_permissao_0600(running_server):
+    _server, socket_path, _ = running_server
+    import stat
+
+    mode = stat.S_IMODE(socket_path.stat().st_mode)
+    assert mode == 0o600


### PR DESCRIPTION
## Resumo
IpcServer async com 8 metodos v1 + IpcClient + integracao com Daemon.

## Escopo
- NDJSON UTF-8 em Unix socket 0600 (`\$XDG_RUNTIME_DIR/hefesto.sock`).
- 8 metodos v1; codigos de erro domain documentados.
- Cliente com context manager.
- Daemon sobe/derruba IPC junto do ciclo de vida.
- 13 testes ponta-a-ponta (180 total).

## Runtime checks
- `ruff check`: pass
- `mypy` strict (30): pass
- `pytest tests/unit -v`: **180 passed**
- `scripts/check_anonymity.sh`: OK

Closes #9