### PR TITLE
W5.3: CLI completo (status, battery, led, test)

### DIFF
--- a/src/hefesto/cli/app.py
+++ b/src/hefesto/cli/app.py
@@ -27,8 +27,36 @@ daemon_app = typer.Typer(
 app.add_typer(daemon_app, name="daemon")
 
 from hefesto.cli.cmd_profile import app as profile_app  # noqa: E402
+from hefesto.cli.cmd_test import app as test_app  # noqa: E402
 
 app.add_typer(profile_app, name="profile")
+app.add_typer(test_app, name="test")
+
+
+@app.command()
+def status() -> None:
+    """Mostra status do daemon e do controle."""
+    from hefesto.cli.cmd_status import status_cmd
+
+    status_cmd()
+
+
+@app.command()
+def battery() -> None:
+    """Percentual de bateria do controle."""
+    from hefesto.cli.cmd_status import battery_cmd
+
+    battery_cmd()
+
+
+@app.command()
+def led(
+    color: str = typer.Option(..., help="Hex (#RRGGBB) ou CSV R,G,B."),
+) -> None:
+    """Define a cor da lightbar direto no controle."""
+    from hefesto.cli.cmd_test import cmd_led
+
+    cmd_led(color=color)
 
 
 @app.command()

--- a/src/hefesto/cli/cmd_status.py
+++ b/src/hefesto/cli/cmd_status.py
@@ -1,0 +1,83 @@
+"""Subcomandos `hefesto status` e `hefesto battery`.
+
+Falam com o daemon via IPC para apresentar informação atual ao usuário.
+Se o daemon estiver parado, tenta ler o controle direto como fallback.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from hefesto.cli.ipc_client import IpcClient, IpcError
+
+console = Console()
+
+
+async def _daemon_status_via_ipc() -> dict[str, Any] | None:
+    try:
+        async with IpcClient.connect() as client:
+            result = await client.call("daemon.status")
+            if isinstance(result, dict):
+                return result
+            return None
+    except (FileNotFoundError, ConnectionError, IpcError):
+        return None
+
+
+def status_cmd() -> None:
+    """Tabela com bateria + perfil + conexão + transporte."""
+    data = asyncio.run(_daemon_status_via_ipc())
+    if data is None:
+        console.print("[yellow]daemon offline — mostrando leitura direta do hardware[/yellow]")
+        data = _fallback_hardware_read()
+
+    table = Table(title="Hefesto — Status")
+    table.add_column("Campo", style="cyan")
+    table.add_column("Valor")
+    for key in ("connected", "transport", "active_profile", "battery_pct"):
+        value = data.get(key)
+        table.add_row(key, str(value) if value is not None else "[dim]n/d[/dim]")
+    console.print(table)
+
+
+def battery_cmd() -> None:
+    """Mostra só o percentual de bateria."""
+    data = asyncio.run(_daemon_status_via_ipc())
+    if data is None:
+        data = _fallback_hardware_read()
+    battery = data.get("battery_pct")
+    if battery is None:
+        console.print("[red]bateria desconhecida[/red]")
+        raise typer.Exit(code=1)
+    color = "green" if battery > 40 else "yellow" if battery > 15 else "red"
+    console.print(f"[{color}]{battery}%[/{color}]")
+
+
+def _fallback_hardware_read() -> dict[str, Any]:
+    try:
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+
+        controller = PyDualSenseController()
+        controller.connect()
+        try:
+            state = controller.read_state()
+            return {
+                "connected": state.connected,
+                "transport": state.transport,
+                "active_profile": None,
+                "battery_pct": state.battery_pct,
+            }
+        finally:
+            with contextlib.suppress(Exception):
+                controller.disconnect()
+    except Exception as exc:
+        console.print(f"[red]sem controle disponivel: {exc}[/red]")
+        return {"connected": False, "transport": None, "active_profile": None, "battery_pct": None}
+
+
+__all__ = ["battery_cmd", "status_cmd"]

--- a/src/hefesto/cli/cmd_test.py
+++ b/src/hefesto/cli/cmd_test.py
@@ -1,0 +1,112 @@
+"""Subcomando `hefesto test ...`.
+
+Operação direta no controle (não pelo daemon). Útil para exercitar
+efeitos sem precisar do daemon rodando. Se quiser operar via daemon
+rodando, envie trigger.set/led.set pelo IPC.
+"""
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable
+from typing import Any, Literal
+
+import typer
+from rich.console import Console
+
+from hefesto.core.controller import IController
+from hefesto.core.led_control import hex_to_rgb
+from hefesto.core.trigger_effects import build_from_name
+
+app = typer.Typer(name="test", help="Exercita efeitos direto no hardware.", no_args_is_help=True)
+console = Console()
+
+
+def _parse_params(raw: str | None) -> list[int]:
+    if not raw:
+        return []
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    try:
+        return [int(p) for p in parts]
+    except ValueError as exc:
+        raise typer.BadParameter(f"params: inteiros separados por virgula. Erro: {exc}") from None
+
+
+@app.command("trigger")
+def cmd_trigger(
+    side: str = typer.Option(..., help="left ou right"),
+    mode: str = typer.Option(..., help="Nome do preset (Rigid, Galloping, ...)."),
+    params: str | None = typer.Option(None, help="CSV de inteiros: '0,9,7,7,10'"),
+    raw: bool = typer.Option(
+        False, "--raw", help="mode e valor inteiro (0-255); params sao 7 bytes HID."
+    ),
+) -> None:
+    if side not in ("left", "right"):
+        raise typer.BadParameter("side deve ser left ou right")
+    side_literal: Literal["left", "right"] = "left" if side == "left" else "right"
+
+    params_list = _parse_params(params)
+
+    if raw:
+        from hefesto.core.controller import TriggerEffect
+
+        try:
+            mode_int = int(mode)
+        except ValueError:
+            raise typer.BadParameter("modo --raw exige inteiro em --mode") from None
+        if len(params_list) != 7:
+            raise typer.BadParameter("modo --raw exige 7 valores em --params")
+        effect = TriggerEffect(
+            mode=mode_int,
+            forces=(
+                params_list[0], params_list[1], params_list[2], params_list[3],
+                params_list[4], params_list[5], params_list[6],
+            ),
+        )
+    else:
+        effect = build_from_name(mode, params_list)
+
+    _apply_on_hardware(lambda c: c.set_trigger(side_literal, effect))
+    console.print(f"[green]trigger aplicado: {side_literal} {mode} {params_list}[/green]")
+
+
+@app.command("led")
+def cmd_led(
+    color: str = typer.Option(..., help="Cor em hex (#FF0080) ou nome r,g,b."),
+) -> None:
+    rgb = hex_to_rgb(color) if color.startswith("#") or len(color) == 6 else _parse_rgb_csv(color)
+    _apply_on_hardware(lambda c: c.set_led(rgb))
+    console.print(f"[green]lightbar: rgb={rgb}[/green]")
+
+
+@app.command("rumble")
+def cmd_rumble(
+    weak: int = typer.Option(0, min=0, max=255),
+    strong: int = typer.Option(0, min=0, max=255),
+) -> None:
+    _apply_on_hardware(lambda c: c.set_rumble(weak=weak, strong=strong))
+    console.print(f"[green]rumble: weak={weak} strong={strong}[/green]")
+
+
+def _parse_rgb_csv(value: str) -> tuple[int, int, int]:
+    parts = [int(p.strip()) for p in value.split(",")]
+    if len(parts) != 3:
+        raise typer.BadParameter("formato: R,G,B (3 valores 0-255)")
+    for idx, b in enumerate(parts):
+        if not (0 <= b <= 255):
+            raise typer.BadParameter(f"rgb[{idx}] fora de 0-255")
+    return (parts[0], parts[1], parts[2])
+
+
+def _apply_on_hardware(action: Callable[[IController], Any]) -> None:
+    from hefesto.core.backend_pydualsense import PyDualSenseController
+
+    controller = PyDualSenseController()
+    try:
+        controller.connect()
+        action(controller)
+    finally:
+        with contextlib.suppress(Exception):
+            controller.disconnect()
+
+
+__all__ = ["app"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,111 @@
+"""Testes da CLI via typer.testing.CliRunner."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from hefesto.cli.app import app
+from hefesto.profiles import loader as loader_module
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def isolated_profiles_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "profiles"
+    target.mkdir()
+
+    def fake_profiles_dir(ensure: bool = False) -> Path:
+        if ensure:
+            target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    monkeypatch.setattr(loader_module, "profiles_dir", fake_profiles_dir)
+    # Também aponta config_dir para tmp para active_profile marker.
+    from hefesto.utils import xdg_paths
+
+    fake_cfg = tmp_path / "config"
+    fake_cfg.mkdir()
+
+    def fake_config_dir(ensure: bool = False) -> Path:
+        if ensure:
+            fake_cfg.mkdir(parents=True, exist_ok=True)
+        return fake_cfg
+
+    monkeypatch.setattr(xdg_paths, "config_dir", fake_config_dir)
+    return target
+
+
+def test_version_command():
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "0.1.0"
+
+
+def test_profile_list_vazio(isolated_profiles_dir: Path):
+    result = runner.invoke(app, ["profile", "list"])
+    assert result.exit_code == 0
+    assert "nenhum perfil" in result.stdout
+
+
+def test_profile_create_e_list(isolated_profiles_dir: Path):
+    r1 = runner.invoke(app, ["profile", "create", "teste", "--match-class", "Firefox"])
+    assert r1.exit_code == 0
+
+    r2 = runner.invoke(app, ["profile", "list"])
+    assert r2.exit_code == 0
+    assert "teste" in r2.stdout
+    assert "Firefox" in r2.stdout
+
+
+def test_profile_create_fallback(isolated_profiles_dir: Path):
+    r = runner.invoke(app, ["profile", "create", "fb", "--fallback"])
+    assert r.exit_code == 0
+
+    r2 = runner.invoke(app, ["profile", "show", "fb"])
+    assert r2.exit_code == 0
+    assert '"type": "any"' in r2.stdout
+    assert '"priority": 0' in r2.stdout
+
+
+def test_profile_show_inexistente(isolated_profiles_dir: Path):
+    result = runner.invoke(app, ["profile", "show", "ghost"])
+    assert result.exit_code == 1
+    assert "nao encontrado" in result.stdout
+
+
+def test_profile_delete_com_yes(isolated_profiles_dir: Path):
+    runner.invoke(app, ["profile", "create", "tmp", "--match-class", "X"])
+    r = runner.invoke(app, ["profile", "delete", "tmp", "--yes"])
+    assert r.exit_code == 0
+
+
+def test_battery_sem_hardware():
+    # Sem daemon e sem hardware: retorna exit code 1 com mensagem.
+    result = runner.invoke(app, ["battery"])
+    # O fallback tenta ler hardware; se não disponível, sai com 1.
+    assert result.exit_code in (0, 1)
+
+
+def test_status_roda_sem_daemon():
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "Hefesto" in result.stdout or "Status" in result.stdout
+
+
+def test_daemon_install_service_dry_command_help():
+    # Apenas valida que subcomando existe e aceita --help.
+    result = runner.invoke(app, ["daemon", "install-service", "--help"])
+    assert result.exit_code == 0
+    assert "headless" in result.stdout
+
+
+def test_test_trigger_sem_hardware_nao_explode():
+    result = runner.invoke(
+        app,
+        ["test", "trigger", "--side", "right", "--mode", "Rigid", "--params", "5,200"],
+    )
+    # Sem hardware: não explode; saída pode indicar erro mas exit code controlado.
+    assert result.exit_code in (0, 1)


### PR DESCRIPTION
## Resumo
Subcomandos CLI completos usando IPC quando daemon esta ativo, com fallback direto pro hardware.

## Escopo
- `hefesto status/battery` via IpcClient, fallback hardware.
- `hefesto test trigger/led/rumble` direto.
- `hefesto led --color #FF0080` atalho.
- `--raw` no test trigger para mode inteiro + 7 forces HID.
- 10 testes (205 total).

## Runtime checks
- ruff, mypy (33), pytest 205 passed, anonimato OK.

Closes #13