### PR TITLE
HOTFIX-1: backend pydualsense le triggers e battery corretamente

### DIFF
--- a/src/hefesto/core/backend_pydualsense.py
+++ b/src/hefesto/core/backend_pydualsense.py
@@ -51,16 +51,24 @@ class PyDualSenseController(IController):
             self._ds = None
 
     def is_connected(self) -> bool:
-        return self._ds is not None and self._ds.conType is not None
+        if self._ds is None:
+            return False
+        # `ds.connected` é o canônico do pydualsense (bool); conType existe
+        # mas pode estar setado mesmo depois de close.
+        return bool(getattr(self._ds, "connected", True))
 
     def read_state(self) -> ControllerState:
         ds = self._require()
         state = ds.state
         battery = self._read_battery_raw(ds)
+        # HOTFIX-1: triggers analógicos vivem em L2_value/R2_value (0-255).
+        # state.L2 / state.R2 são bool "botão pressionado", truncam analog.
+        l2_raw = int(getattr(state, "L2_value", 0)) & 0xFF
+        r2_raw = int(getattr(state, "R2_value", 0)) & 0xFF
         return ControllerState(
             battery_pct=battery,
-            l2_raw=int(state.L2),
-            r2_raw=int(state.R2),
+            l2_raw=l2_raw,
+            r2_raw=r2_raw,
             connected=self.is_connected(),
             transport=self._transport,
             raw_lx=int(state.LX) & 0xFF,
@@ -107,10 +115,14 @@ class PyDualSenseController(IController):
 
     @staticmethod
     def _read_battery_raw(ds: pydualsense) -> int:
-        battery = getattr(ds.state, "battery", None)
+        # HOTFIX-1: battery vive em `ds.battery` (top-level), não em ds.state.
+        # DSBattery expõe `Level` (0-100) e `State` (enum BatteryState).
+        battery = getattr(ds, "battery", None)
         if battery is None:
             return 0
-        level = getattr(battery, "Level", battery)
+        level = getattr(battery, "Level", None)
+        if level is None:
+            return 0
         try:
             value = int(level)
         except (TypeError, ValueError):

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -141,3 +141,81 @@ class TestPyDualSenseController:
 
         coerced = PyDualSenseController._coerce_mode(0x99)
         assert coerced == 0x99
+
+    def test_read_state_usa_analog_trigger_values(self) -> None:
+        """HOTFIX-1: trigger analog vem de L2_value/R2_value, nao L2/R2."""
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+
+        class FakeState:
+            L2 = False
+            R2 = True
+            L2_value = 180  # meio-pressionado
+            R2_value = 255  # totalmente pressionado
+            LX = 128
+            LY = 128
+            RX = 128
+            RY = 128
+
+        class FakeBattery:
+            Level = 73
+
+        class FakeDs:
+            state = FakeState()
+            battery = FakeBattery()
+            connected = True
+
+        inst = PyDualSenseController()
+        inst._ds = FakeDs()  # type: ignore[assignment]
+        inst._transport = "usb"
+
+        state = inst.read_state()
+        assert state.l2_raw == 180
+        assert state.r2_raw == 255
+        assert state.battery_pct == 73
+        assert state.connected is True
+        assert state.transport == "usb"
+
+    def test_read_state_battery_zerado_quando_ausente(self) -> None:
+        """Se ds.battery ausente ou Level None, retorna 0 sem explodir."""
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+
+        class FakeState:
+            L2_value = 0
+            R2_value = 0
+            LX = 128
+            LY = 128
+            RX = 128
+            RY = 128
+
+        class FakeDs:
+            state = FakeState()
+            battery = None
+            connected = True
+
+        inst = PyDualSenseController()
+        inst._ds = FakeDs()  # type: ignore[assignment]
+        inst._transport = "bt"
+
+        state = inst.read_state()
+        assert state.battery_pct == 0
+
+    def test_is_connected_false_quando_disconnected_prop(self) -> None:
+        """HOTFIX-1: is_connected usa ds.connected, nao conType."""
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+
+        class FakeDs:
+            connected = False
+
+        inst = PyDualSenseController()
+        inst._ds = FakeDs()  # type: ignore[assignment]
+        assert inst.is_connected() is False
+
+    def test_is_connected_true_quando_connected_prop(self) -> None:
+        from hefesto.core.backend_pydualsense import PyDualSenseController
+
+        class FakeDs:
+            connected = True
+
+        inst = PyDualSenseController()
+        inst._ds = FakeDs()  # type: ignore[assignment]
+        assert inst.is_connected() is True


### PR DESCRIPTION
## Resumo
3 bugs de atributo lidos no W1.1 descobertos durante smoke runtime de INFRA.2 contra hardware real.

## Correcoes
- state.L2_value / R2_value (0-255 analog), nao state.L2/R2 (bool).
- ds.battery.Level (ds top-level), nao ds.state.battery.
- is_connected usa ds.connected canonico.

## Prova
- Antes: battery_pct = 0 sempre, L2/R2 truncado em 0/1.
- Depois: battery_pct = 100 lido do device via USB.
- Mock tests cobrem os 3 paths.

## Limitacao runtime
Triggers nao sobem em runtime real por conflito com kernel `hid_playstation` — rastreado em #49 (HOTFIX-2).

Closes #48
Relacionado: #49