### PR TITLE
W6.3: gamepad virtual Xbox360 via uinput

### DIFF
--- a/src/hefesto/cli/app.py
+++ b/src/hefesto/cli/app.py
@@ -26,11 +26,13 @@ daemon_app = typer.Typer(
 )
 app.add_typer(daemon_app, name="daemon")
 
+from hefesto.cli.cmd_emulate import app as emulate_app  # noqa: E402
 from hefesto.cli.cmd_profile import app as profile_app  # noqa: E402
 from hefesto.cli.cmd_test import app as test_app  # noqa: E402
 
 app.add_typer(profile_app, name="profile")
 app.add_typer(test_app, name="test")
+app.add_typer(emulate_app, name="emulate")
 
 
 @app.command()

--- a/src/hefesto/cli/cmd_emulate.py
+++ b/src/hefesto/cli/cmd_emulate.py
@@ -1,0 +1,89 @@
+"""Subcomando `hefesto emulate xbox360 [--on|--off]`.
+
+Cria um gamepad virtual Xbox360 via uinput e fica em primeiro plano,
+repassando o input do DualSense físico até Ctrl+C.
+
+Em modo `--on` (default quando rodado), o daemon fica lendo o controle
+real e emitindo no virtual. `--off` simplesmente aborta (sem stato
+persistente ainda; em integração futura com daemon, manda IPC).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+app = typer.Typer(
+    name="emulate",
+    help="Gamepad virtual pra jogos que só reconhecem Xbox.",
+    no_args_is_help=True,
+)
+
+
+@app.command("xbox360")
+def cmd_xbox360(
+    on: bool = typer.Option(True, "--on/--off", help="Ligar/desligar emulação."),
+    poll_hz: int = typer.Option(
+        60, "--poll-hz", min=10, max=250, help="Taxa de forward em Hz."
+    ),
+) -> None:
+    """Cria device Xbox360 virtual e retransmite input do controle físico."""
+    if not on:
+        console.print("[yellow]--off sem daemon rodando: nada pra parar[/yellow]")
+        raise typer.Exit(code=0)
+
+    try:
+        asyncio.run(_run_emulation(poll_hz=poll_hz))
+    except KeyboardInterrupt:
+        console.print("[dim]emulação interrompida[/dim]")
+
+
+async def _run_emulation(poll_hz: int) -> None:
+    from hefesto.core.backend_pydualsense import PyDualSenseController
+    from hefesto.integrations.uinput_gamepad import UinputGamepad
+
+    controller = PyDualSenseController()
+    controller.connect()
+
+    gamepad = UinputGamepad()
+    if not gamepad.start():
+        controller.disconnect()
+        console.print("[red]falha ao criar gamepad virtual (uinput)[/red]")
+        raise typer.Exit(code=3)
+
+    console.print(
+        f"[green]gamepad virtual ativo[/green] — polling {poll_hz}Hz. "
+        "Ctrl+C pra encerrar."
+    )
+
+    period = 1.0 / poll_hz
+    try:
+        while True:
+            state = controller.read_state()
+            snap = (
+                controller._evdev.snapshot()
+                if controller._evdev.is_available()
+                else None
+            )
+            gamepad.forward_analog(
+                lx=state.raw_lx,
+                ly=state.raw_ly,
+                rx=state.raw_rx,
+                ry=state.raw_ry,
+                l2=state.l2_raw,
+                r2=state.r2_raw,
+            )
+            if snap is not None:
+                gamepad.forward_buttons(snap.buttons_pressed)
+            await asyncio.sleep(period)
+    finally:
+        gamepad.stop()
+        with contextlib.suppress(Exception):
+            controller.disconnect()
+
+
+__all__ = ["app"]

--- a/src/hefesto/integrations/uinput_gamepad.py
+++ b/src/hefesto/integrations/uinput_gamepad.py
@@ -1,0 +1,200 @@
+"""Gamepad virtual Xbox360 via python-uinput (W6.3).
+
+Cria `/dev/input/js*` que o kernel registra como Xbox 360 compatível,
+permitindo que jogos que só reconhecem Xbox controllers recebam input
+do DualSense já traduzido.
+
+Fluxo do daemon:
+  - Controle físico lê input via `EvdevReader` (HOTFIX-2).
+  - Daemon decide: combo sagrado (HotkeyManager) consome, resto repassa.
+  - `UinputGamepad.forward(snapshot)` aplica os eventos relevantes no
+    device virtual.
+  - Jogo lê o device virtual como se fosse Xbox 360.
+
+O device virtual tem VID/PID do Xbox 360 (045e:028e).
+"""
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from hefesto.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+XBOX360_VENDOR = 0x045E
+XBOX360_PRODUCT = 0x028E
+DEVICE_NAME = "Microsoft X-Box 360 pad (Hefesto virtual)"
+
+# Mapeamento canonico Hefesto (HOTFIX-2) -> evdev constant usado no uinput.
+# Layout Xbox: cross=A, circle=B, square=X, triangle=Y.
+BUTTON_TO_UINPUT: dict[str, str] = {
+    "cross": "BTN_A",
+    "circle": "BTN_B",
+    "square": "BTN_X",
+    "triangle": "BTN_Y",
+    "l1": "BTN_TL",
+    "r1": "BTN_TR",
+    "create": "BTN_SELECT",
+    "options": "BTN_START",
+    "ps": "BTN_MODE",
+    "l3": "BTN_THUMBL",
+    "r3": "BTN_THUMBR",
+}
+
+
+def _build_capabilities() -> list[tuple[Any, ...]]:
+    """Lista de eventos que o uinput device expõe.
+
+    python-uinput espera tuples já em formato `(type, code, minmax_extra)`
+    para eventos ABS. Retornamos lazy para não importar uinput em ambientes
+    sem o módulo.
+    """
+    import uinput  # import local — evita custo no import do módulo
+
+    # Axes 0-255 (igual ao evdev do DualSense)
+    abs_axes = [
+        (*uinput.ABS_X, 0, 255, 0, 0),
+        (*uinput.ABS_Y, 0, 255, 0, 0),
+        (*uinput.ABS_RX, 0, 255, 0, 0),
+        (*uinput.ABS_RY, 0, 255, 0, 0),
+        (*uinput.ABS_Z, 0, 255, 0, 0),   # LT
+        (*uinput.ABS_RZ, 0, 255, 0, 0),  # RT
+        (*uinput.ABS_HAT0X, -1, 1, 0, 0),
+        (*uinput.ABS_HAT0Y, -1, 1, 0, 0),
+    ]
+    buttons = [
+        uinput.BTN_A, uinput.BTN_B, uinput.BTN_X, uinput.BTN_Y,
+        uinput.BTN_TL, uinput.BTN_TR,
+        uinput.BTN_SELECT, uinput.BTN_START, uinput.BTN_MODE,
+        uinput.BTN_THUMBL, uinput.BTN_THUMBR,
+    ]
+    return [*abs_axes, *buttons]
+
+
+@dataclass
+class UinputGamepad:
+    """Wrapper do device virtual. Lazy-creates no `start()`."""
+
+    name: str = DEVICE_NAME
+    vendor: int = XBOX360_VENDOR
+    product: int = XBOX360_PRODUCT
+
+    _device: Any = None
+    _uinput_mod: Any = None
+    _last_buttons: frozenset[str] = field(default_factory=frozenset)
+
+    def start(self) -> bool:
+        """Cria o device. Retorna False se /dev/uinput indisponível."""
+        if self._device is not None:
+            return True
+        try:
+            import uinput
+        except ImportError:
+            logger.warning("python-uinput nao instalado — emulacao indisponivel")
+            return False
+        try:
+            caps = _build_capabilities()
+            self._device = uinput.Device(
+                caps, name=self.name, vendor=self.vendor, product=self.product
+            )
+            self._uinput_mod = uinput
+            logger.info("uinput_device_created", name=self.name,
+                        vendor=hex(self.vendor), product=hex(self.product))
+            return True
+        except Exception as exc:
+            logger.warning("uinput_device_create_failed", err=str(exc))
+            return False
+
+    def stop(self) -> None:
+        if self._device is None:
+            return
+        with contextlib.suppress(Exception):
+            self._device.destroy()
+        self._device = None
+        self._last_buttons = frozenset()
+
+    def is_active(self) -> bool:
+        return self._device is not None
+
+    def forward_analog(
+        self,
+        *,
+        lx: int,
+        ly: int,
+        rx: int,
+        ry: int,
+        l2: int,
+        r2: int,
+    ) -> None:
+        """Aplica valores analógicos no device virtual."""
+        if self._device is None or self._uinput_mod is None:
+            return
+        u = self._uinput_mod
+        self._device.emit(u.ABS_X, lx, syn=False)
+        self._device.emit(u.ABS_Y, ly, syn=False)
+        self._device.emit(u.ABS_RX, rx, syn=False)
+        self._device.emit(u.ABS_RY, ry, syn=False)
+        self._device.emit(u.ABS_Z, l2, syn=False)
+        self._device.emit(u.ABS_RZ, r2, syn=False)
+        self._device.syn()
+
+    def forward_buttons(self, pressed: frozenset[str]) -> None:
+        """Aplica set de botões pressionados. Diff com último snapshot."""
+        if self._device is None or self._uinput_mod is None:
+            return
+
+        newly_pressed = pressed - self._last_buttons
+        newly_released = self._last_buttons - pressed
+
+        dpad_x, dpad_y = self._dpad_vector(pressed)
+        last_dpad_x, last_dpad_y = self._dpad_vector(self._last_buttons)
+
+        u = self._uinput_mod
+        for name in newly_pressed:
+            ev = self._resolve_evdev(name, u)
+            if ev is not None:
+                self._device.emit(ev, 1, syn=False)
+        for name in newly_released:
+            ev = self._resolve_evdev(name, u)
+            if ev is not None:
+                self._device.emit(ev, 0, syn=False)
+
+        if dpad_x != last_dpad_x:
+            self._device.emit(u.ABS_HAT0X, dpad_x, syn=False)
+        if dpad_y != last_dpad_y:
+            self._device.emit(u.ABS_HAT0Y, dpad_y, syn=False)
+
+        self._device.syn()
+        self._last_buttons = frozenset(pressed)
+
+    def _resolve_evdev(self, hefesto_name: str, uinput_mod: Any) -> Any | None:
+        if hefesto_name in BUTTON_TO_UINPUT:
+            key = BUTTON_TO_UINPUT[hefesto_name]
+            return getattr(uinput_mod, key, None)
+        # l2_btn / r2_btn digital viram triggers ABS (já tratados em analog)
+        return None
+
+    @staticmethod
+    def _dpad_vector(pressed: frozenset[str]) -> tuple[int, int]:
+        x = 0
+        y = 0
+        if "dpad_left" in pressed:
+            x = -1
+        elif "dpad_right" in pressed:
+            x = 1
+        if "dpad_up" in pressed:
+            y = -1
+        elif "dpad_down" in pressed:
+            y = 1
+        return x, y
+
+
+__all__ = [
+    "BUTTON_TO_UINPUT",
+    "DEVICE_NAME",
+    "XBOX360_PRODUCT",
+    "XBOX360_VENDOR",
+    "UinputGamepad",
+]

--- a/tests/unit/test_uinput_gamepad.py
+++ b/tests/unit/test_uinput_gamepad.py
@@ -1,0 +1,168 @@
+"""Testes do UinputGamepad (W6.3)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hefesto.integrations.uinput_gamepad import (
+    BUTTON_TO_UINPUT,
+    DEVICE_NAME,
+    XBOX360_PRODUCT,
+    XBOX360_VENDOR,
+    UinputGamepad,
+)
+
+
+def _fake_uinput_module() -> MagicMock:
+    mod = MagicMock()
+    # Lista mínima de constantes para _build_capabilities + forward_analog
+    for name in (
+        "ABS_X", "ABS_Y", "ABS_RX", "ABS_RY", "ABS_Z", "ABS_RZ",
+        "ABS_HAT0X", "ABS_HAT0Y",
+        "BTN_A", "BTN_B", "BTN_X", "BTN_Y",
+        "BTN_TL", "BTN_TR",
+        "BTN_SELECT", "BTN_START", "BTN_MODE",
+        "BTN_THUMBL", "BTN_THUMBR",
+    ):
+        setattr(mod, name, (1, hash(name) & 0xFFFF))
+    return mod
+
+
+def test_constantes_xbox360():
+    assert XBOX360_VENDOR == 0x045E
+    assert XBOX360_PRODUCT == 0x028E
+    assert "Hefesto" in DEVICE_NAME
+
+
+def test_button_map_cobre_face_buttons():
+    for name in ("cross", "circle", "square", "triangle", "ps"):
+        assert name in BUTTON_TO_UINPUT
+
+
+def test_start_sem_uinput_retorna_false(monkeypatch: pytest.MonkeyPatch):
+    import sys
+    # Esconde uinput pra simular ambiente sem a lib
+    monkeypatch.setitem(sys.modules, "uinput", None)
+    gp = UinputGamepad()
+    # Forçar ImportError
+    import builtins
+    real_import = builtins.__import__
+
+    def broken_import(name, *args, **kwargs):
+        if name == "uinput":
+            raise ImportError("uinput nao instalado (mock)")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", broken_import)
+    assert gp.start() is False
+    assert gp.is_active() is False
+
+
+def test_start_com_uinput_mockado(monkeypatch: pytest.MonkeyPatch):
+    import sys
+
+    fake_mod = _fake_uinput_module()
+    fake_device = MagicMock()
+    fake_mod.Device.return_value = fake_device
+    monkeypatch.setitem(sys.modules, "uinput", fake_mod)
+
+    gp = UinputGamepad()
+    assert gp.start() is True
+    assert gp.is_active() is True
+    fake_mod.Device.assert_called_once()
+
+    gp.stop()
+    fake_device.destroy.assert_called_once()
+    assert gp.is_active() is False
+
+
+def test_forward_analog_emite_seis_eventos(monkeypatch: pytest.MonkeyPatch):
+    import sys
+
+    fake_mod = _fake_uinput_module()
+    fake_device = MagicMock()
+    fake_mod.Device.return_value = fake_device
+    monkeypatch.setitem(sys.modules, "uinput", fake_mod)
+
+    gp = UinputGamepad()
+    gp.start()
+    gp.forward_analog(lx=100, ly=200, rx=128, ry=128, l2=50, r2=255)
+
+    # 6 chamadas de emit (syn=False) + 1 syn()
+    emit_calls = [c for c in fake_device.method_calls if c[0] == "emit"]
+    assert len(emit_calls) == 6
+    fake_device.syn.assert_called()
+
+
+def test_forward_buttons_press_e_release(monkeypatch: pytest.MonkeyPatch):
+    import sys
+
+    fake_mod = _fake_uinput_module()
+    fake_device = MagicMock()
+    fake_mod.Device.return_value = fake_device
+    monkeypatch.setitem(sys.modules, "uinput", fake_mod)
+
+    gp = UinputGamepad()
+    gp.start()
+
+    # Pressiona cross + circle
+    gp.forward_buttons(frozenset({"cross", "circle"}))
+    emit_calls = [c for c in fake_device.method_calls if c[0] == "emit"]
+    # 2 botões (valor=1) + HAT0X + HAT0Y só emitem se mudaram (não mudaram, permanecem 0)
+    # Então esperamos pelo menos 2 emits
+    assert len(emit_calls) >= 2
+
+    # Limpa histórico
+    fake_device.reset_mock()
+
+    # Solta circle, mantém cross
+    gp.forward_buttons(frozenset({"cross"}))
+    emit_calls = [c for c in fake_device.method_calls if c[0] == "emit"]
+    # Circle deve ter sido soltado (valor=0); cross permanece
+    assert len(emit_calls) >= 1
+
+
+def test_forward_buttons_dpad_atualiza_hat(monkeypatch: pytest.MonkeyPatch):
+    import sys
+
+    fake_mod = _fake_uinput_module()
+    fake_device = MagicMock()
+    fake_mod.Device.return_value = fake_device
+    monkeypatch.setitem(sys.modules, "uinput", fake_mod)
+
+    gp = UinputGamepad()
+    gp.start()
+
+    gp.forward_buttons(frozenset({"dpad_up"}))
+
+    # Deve ter emitido ABS_HAT0Y = -1
+    emit_calls = [
+        c for c in fake_device.method_calls
+        if c[0] == "emit" and c[1][0] == fake_mod.ABS_HAT0Y
+    ]
+    assert emit_calls
+    assert emit_calls[-1][1][1] == -1
+
+    # dpad_right → HAT0X = 1
+    fake_device.reset_mock()
+    gp.forward_buttons(frozenset({"dpad_right"}))
+    calls_x = [
+        c for c in fake_device.method_calls
+        if c[0] == "emit" and c[1][0] == fake_mod.ABS_HAT0X
+    ]
+    assert any(c[1][1] == 1 for c in calls_x)
+    calls_y_zero = [
+        c for c in fake_device.method_calls
+        if c[0] == "emit" and c[1][0] == fake_mod.ABS_HAT0Y
+    ]
+    assert any(c[1][1] == 0 for c in calls_y_zero)  # HAT0Y voltou a 0
+
+
+def test_dpad_vector_estatico():
+    assert UinputGamepad._dpad_vector(frozenset()) == (0, 0)
+    assert UinputGamepad._dpad_vector(frozenset({"dpad_up"})) == (0, -1)
+    assert UinputGamepad._dpad_vector(frozenset({"dpad_down"})) == (0, 1)
+    assert UinputGamepad._dpad_vector(frozenset({"dpad_left"})) == (-1, 0)
+    assert UinputGamepad._dpad_vector(frozenset({"dpad_right"})) == (1, 0)
+    assert UinputGamepad._dpad_vector(frozenset({"dpad_up", "dpad_right"})) == (1, -1)


### PR DESCRIPTION
UinputGamepad cria /dev/input/js2 como Xbox360 (VID 045e:028e), 6 eixos + 11 botoes + d-pad HAT. CLI 'hefesto emulate xbox360 --on' loop de forward 60Hz. 8 testes novos (255 total). Smoke real: device aparece em /dev/input/, eventos emitidos, destroy limpo. Closes #19