### PR TITLE
fix: daemon não iniciava ao abrir GUI (BUG-DAEMON-AUTOSTART-01)

### DIFF
--- a/docs/process/sprints/BUG-DAEMON-AUTOSTART-01.md
+++ b/docs/process/sprints/BUG-DAEMON-AUTOSTART-01.md
@@ -31,7 +31,7 @@ Segundo vetor: a GUI, ao abrir, pode tentar conectar no IPC e falhar (daemon mor
   - Chama `systemctl --user is-active hefesto.service`; se não `active`, dispara `systemctl --user start hefesto.service` com timeout 5s.
   - Nunca bloqueia a thread GTK; falha silenciosa com `logger.warning`.
 - [ ] Teste manual: fechar GUI, `systemctl --user stop hefesto.service`, reabrir GUI. Header deve mostrar "Tentando Reconectar" inicialmente e migrar para "Conectado Via USB" em até 5s sem intervenção.
-- [ ] `assets/hefesto.service` mantém `After=graphical-session.target` e ganha também `Wants=hefesto.service` ou equivalente para encorajar auto-start.
+- [x] `assets/hefesto.service` mantém `After=graphical-session.target`. `Wants=` dispensado — `WantedBy=graphical-session.target` no bloco `[Install]` já garante ativação por sessão via `systemctl --user enable` (executado por `hefesto daemon install-service`).
 - [ ] `.venv/bin/pytest tests/unit -q` verde.
 
 ## Proof-of-work

--- a/install.sh
+++ b/install.sh
@@ -183,6 +183,7 @@ if [[ "${SKIP_SYSTEMD}" -eq 1 ]]; then
     log "[6/6] unit systemd pulada (--no-systemd)"
 else
     log "[6/6] unit systemd --user (daemon em background)"
+    # install-service cadeia: daemon-reload + systemctl --user enable hefesto.service
     if "${VENV_DIR}/bin/hefesto" daemon install-service >/dev/null 2>&1; then
         if systemctl --user restart hefesto.service >/dev/null 2>&1; then
             log "daemon ativo (systemctl --user status hefesto.service para detalhes)"

--- a/src/hefesto/app/actions/daemon_actions.py
+++ b/src/hefesto/app/actions/daemon_actions.py
@@ -25,11 +25,101 @@ class DaemonActionsMixin(WidgetAccessMixin):
     """Controla a aba Daemon."""
 
     _daemon_autostart_guard: bool
+    # Contador anti-loop de tentativas de autostart por sessão da GUI.
+    # Máximo 2 tentativas: após a segunda falha, o helper vira no-op até
+    # a próxima reabertura do processo (BUG-DAEMON-AUTOSTART-01).
+    _daemon_autostart_attempts: int = 0
 
     def install_daemon_tab(self) -> None:
         self._daemon_autostart_guard = False
+        # Inicializa contador anti-loop por instância (bootstrap da GUI).
+        self._daemon_autostart_attempts = 0
         self._refresh_daemon_view()
         self._sync_restart_daemon_button_sensitivity()
+
+    def ensure_daemon_running(self) -> None:
+        """Garante daemon ativo no bootstrap da GUI (BUG-DAEMON-AUTOSTART-01).
+
+        Executado em thread worker via `_get_executor()` — nunca bloqueia
+        a thread GTK. Fluxo:
+
+          1. Se `detect_installed_unit()` retorna `None`, no-op (usuário
+             sem unit instalada, provavelmente nunca rodou `install.sh`).
+          2. Se `systemctl --user is-active hefesto.service` já retorna
+             `active`, no-op (daemon já está rodando).
+          3. Caso contrário, dispara `systemctl --user start hefesto.service`
+             com timeout de 5s. Falha silenciosa via `logger.warning`.
+
+        Anti-loop: limite de 2 tentativas por sessão (`_daemon_autostart_attempts`).
+        Após a segunda falha, o helper vira no-op até a próxima abertura
+        do processo da GUI.
+        """
+        if self._daemon_autostart_attempts >= 2:
+            return
+
+        def _worker() -> None:
+            try:
+                installed = ServiceInstaller().detect_installed_unit()
+            except Exception as exc:
+                logger.warning("autostart_detect_falhou", erro=str(exc))
+                return
+            if installed is None:
+                logger.debug("autostart_sem_unit_instalada")
+                return
+
+            active = self._is_service_active()
+            if active == "active":
+                logger.debug("autostart_daemon_ja_ativo")
+                return
+
+            self._daemon_autostart_attempts += 1
+            logger.info(
+                "autostart_disparando",
+                tentativa=self._daemon_autostart_attempts,
+                estado_anterior=active,
+            )
+            rc = self._start_service_blocking()
+            if rc == 0:
+                logger.info("autostart_ok", unit=SERVICE_NORMAL)
+            else:
+                logger.warning(
+                    "autostart_falhou",
+                    unit=SERVICE_NORMAL,
+                    rc=rc,
+                    tentativa=self._daemon_autostart_attempts,
+                )
+
+        _get_executor().submit(_worker)
+
+    def _is_service_active(self) -> str:
+        """Retorna saída de `systemctl --user is-active hefesto.service`.
+
+        Retorna string vazia se systemctl indisponível.
+        """
+        result = self._invoke_systemctl(
+            ["is-active", SERVICE_NORMAL], capture=True, check=False
+        )
+        if result is None:
+            return ""
+        return (result.stdout or "").strip()
+
+    def _start_service_blocking(self) -> int:
+        """Dispara `systemctl --user start hefesto.service` com timeout 5s.
+
+        Retorna o returncode (ou -1 em caso de FileNotFoundError / timeout).
+        Bloqueia — chamar apenas de thread worker.
+        """
+        try:
+            result = subprocess.run(
+                ["systemctl", "--user", "start", SERVICE_NORMAL],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError):
+            return -1
+        return result.returncode
 
     def _sync_restart_daemon_button_sensitivity(self) -> None:
         """Habilita/desabilita o botão 'Reiniciar daemon' conforme unit presente.

--- a/src/hefesto/app/app.py
+++ b/src/hefesto/app/app.py
@@ -173,6 +173,10 @@ class HefestoApp(
         self.install_daemon_tab()
         self.install_emulation_tab()
         self.install_mouse_tab()
+        # BUG-DAEMON-AUTOSTART-01: dispara start do daemon em thread worker
+        # se a unit está instalada mas o service não está ativo. Jamais
+        # bloqueia a thread GTK; falha silenciosa via logger.warning.
+        self.ensure_daemon_running()
 
     def run(self, *, start_hidden: bool = False) -> None:
         self.tray = AppTray(
@@ -191,6 +195,8 @@ class HefestoApp(
             self.install_daemon_tab()
             self.install_emulation_tab()
             self.install_mouse_tab()
+            # BUG-DAEMON-AUTOSTART-01: mesmo no modo oculto, garantir daemon.
+            self.ensure_daemon_running()
             logger.info("hefesto_start_hidden")
         else:
             self.show()

--- a/tests/unit/test_daemon_autostart.py
+++ b/tests/unit/test_daemon_autostart.py
@@ -1,0 +1,256 @@
+"""Testes de `ensure_daemon_running` (BUG-DAEMON-AUTOSTART-01).
+
+Cobre:
+  - No-op quando `detect_installed_unit()` retorna None.
+  - No-op quando o service já está `active`.
+  - Dispara `systemctl --user start hefesto.service` quando inativo.
+  - Respeita limite anti-loop de 2 tentativas por sessão.
+  - Submete trabalho ao executor (não bloqueia a thread chamadora).
+
+Usa stubs `gi` para rodar em CI sem display GTK.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from typing import Any
+
+
+def _install_gi_stubs() -> None:
+    if "gi" in sys.modules and hasattr(sys.modules["gi"], "require_version"):
+        try:
+            from gi.repository import Gtk  # noqa: F401
+
+            return
+        except Exception:  # pragma: no cover — ambientes sem GTK
+            pass
+
+    gi_mod = types.ModuleType("gi")
+
+    def _require_version(_name: str, _ver: str) -> None:
+        return None
+
+    gi_mod.require_version = _require_version  # type: ignore[attr-defined]
+    repo_mod = types.ModuleType("gi.repository")
+    gtk_mod = types.ModuleType("gi.repository.Gtk")
+    glib_mod = types.ModuleType("gi.repository.GLib")
+
+    class _FakeButton:
+        def set_sensitive(self, _v: bool) -> None:
+            pass
+
+        def set_tooltip_text(self, _t: str) -> None:
+            pass
+
+    gtk_mod.Builder = object  # type: ignore[attr-defined]
+    gtk_mod.Window = object  # type: ignore[attr-defined]
+    gtk_mod.Button = _FakeButton  # type: ignore[attr-defined]
+    gtk_mod.ComboBoxText = object  # type: ignore[attr-defined]
+    gtk_mod.Switch = object  # type: ignore[attr-defined]
+    gtk_mod.TextView = object  # type: ignore[attr-defined]
+    gtk_mod.TextBuffer = object  # type: ignore[attr-defined]
+    glib_mod.idle_add = lambda *_a, **_kw: 0  # type: ignore[attr-defined]
+    glib_mod.timeout_add = lambda *_a, **_kw: 0  # type: ignore[attr-defined]
+    glib_mod.timeout_add_seconds = lambda *_a, **_kw: 0  # type: ignore[attr-defined]
+    repo_mod.Gtk = gtk_mod  # type: ignore[attr-defined]
+    repo_mod.GLib = glib_mod  # type: ignore[attr-defined]
+
+    sys.modules["gi"] = gi_mod
+    sys.modules["gi.repository"] = repo_mod
+    sys.modules["gi.repository.Gtk"] = gtk_mod
+    sys.modules["gi.repository.GLib"] = glib_mod
+
+
+_install_gi_stubs()
+
+import pytest  # noqa: E402
+
+from hefesto.app.actions import daemon_actions as da  # noqa: E402
+from hefesto.app.actions.daemon_actions import DaemonActionsMixin  # noqa: E402
+
+
+class _SyncExecutor:
+    """Executor fake que roda o worker inline — sem threads de fato.
+
+    Permite asserts síncronos depois de `ensure_daemon_running()`.
+    """
+
+    def __init__(self) -> None:
+        self.submitted: list[Any] = []
+
+    def submit(self, fn: Any, *args: Any, **kwargs: Any) -> None:
+        self.submitted.append(fn)
+        fn(*args, **kwargs)
+
+
+class _Host(DaemonActionsMixin):
+    """Host mínimo para exercitar o helper sem Builder real."""
+
+    def __init__(self) -> None:
+        self._daemon_autostart_guard = False
+        self._daemon_autostart_attempts = 0
+
+
+@pytest.fixture
+def sync_executor(monkeypatch: pytest.MonkeyPatch) -> _SyncExecutor:
+    exe = _SyncExecutor()
+    monkeypatch.setattr(da, "_get_executor", lambda: exe)
+    return exe
+
+
+@pytest.fixture
+def host() -> _Host:
+    return _Host()
+
+
+def _fake_run_factory(
+    is_active_stdout: str,
+    start_rc: int = 0,
+    raise_on_start: Exception | None = None,
+) -> tuple[list[list[str]], Any]:
+    """Produz um substituto de `subprocess.run` que distingue is-active vs start."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        if "is-active" in cmd:
+            result = subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=is_active_stdout, stderr=""
+            )
+            return result
+        if "start" in cmd:
+            if raise_on_start is not None:
+                raise raise_on_start
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=start_rc, stdout="", stderr=""
+            )
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="", stderr=""
+        )
+
+    return calls, fake_run
+
+
+def test_noop_quando_unit_nao_instalada(
+    host: _Host,
+    sync_executor: _SyncExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Se `detect_installed_unit()` retorna None, não dispara systemctl."""
+    monkeypatch.setattr(
+        da.ServiceInstaller, "detect_installed_unit", lambda self: None
+    )
+    calls, fake_run = _fake_run_factory(is_active_stdout="inactive\n")
+    monkeypatch.setattr(da.subprocess, "run", fake_run)
+
+    host.ensure_daemon_running()
+
+    assert calls == []
+    assert host._daemon_autostart_attempts == 0
+
+
+def test_noop_quando_daemon_ja_ativo(
+    host: _Host,
+    sync_executor: _SyncExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Se is-active retorna `active`, não dispara start."""
+    monkeypatch.setattr(
+        da.ServiceInstaller, "detect_installed_unit", lambda self: "hefesto"
+    )
+    calls, fake_run = _fake_run_factory(is_active_stdout="active\n")
+    monkeypatch.setattr(da.subprocess, "run", fake_run)
+
+    host.ensure_daemon_running()
+
+    # Apenas a chamada is-active deve ter ocorrido — nenhuma start.
+    assert any("is-active" in " ".join(c) for c in calls)
+    # Nenhum cmd contém o argumento literal "start" (exceto "start" dentro de "is-active" — filtrado).
+    started = [c for c in calls if "start" in c and "is-active" not in c]
+    assert started == []
+    assert host._daemon_autostart_attempts == 0
+
+
+def test_dispara_start_quando_inativo(
+    host: _Host,
+    sync_executor: _SyncExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Se is-active != active, dispara systemctl start e incrementa contador."""
+    monkeypatch.setattr(
+        da.ServiceInstaller, "detect_installed_unit", lambda self: "hefesto"
+    )
+    calls, fake_run = _fake_run_factory(
+        is_active_stdout="inactive\n", start_rc=0
+    )
+    monkeypatch.setattr(da.subprocess, "run", fake_run)
+
+    host.ensure_daemon_running()
+
+    started = [c for c in calls if "start" in c and "is-active" not in c]
+    assert len(started) == 1
+    assert "hefesto.service" in started[0]
+    assert host._daemon_autostart_attempts == 1
+
+
+def test_limite_anti_loop_duas_tentativas(
+    host: _Host,
+    sync_executor: _SyncExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Após 2 tentativas, helper vira no-op até próxima sessão."""
+    monkeypatch.setattr(
+        da.ServiceInstaller, "detect_installed_unit", lambda self: "hefesto"
+    )
+    calls, fake_run = _fake_run_factory(
+        is_active_stdout="inactive\n", start_rc=1
+    )
+    monkeypatch.setattr(da.subprocess, "run", fake_run)
+
+    # Três chamadas consecutivas — só duas devem executar start.
+    host.ensure_daemon_running()
+    host.ensure_daemon_running()
+    host.ensure_daemon_running()
+
+    started = [c for c in calls if "start" in c and "is-active" not in c]
+    assert len(started) == 2
+    assert host._daemon_autostart_attempts == 2
+
+
+def test_falha_silenciosa_em_timeout(
+    host: _Host,
+    sync_executor: _SyncExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TimeoutExpired em `start` não propaga; contador ainda incrementa."""
+    monkeypatch.setattr(
+        da.ServiceInstaller, "detect_installed_unit", lambda self: "hefesto"
+    )
+    _calls, fake_run = _fake_run_factory(
+        is_active_stdout="inactive\n",
+        raise_on_start=subprocess.TimeoutExpired(cmd="systemctl", timeout=5),
+    )
+    monkeypatch.setattr(da.subprocess, "run", fake_run)
+
+    # Não deve levantar
+    host.ensure_daemon_running()
+
+    assert host._daemon_autostart_attempts == 1
+
+
+def test_submete_ao_executor(
+    host: _Host,
+    sync_executor: _SyncExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confirma que o helper usa `_get_executor().submit(...)`."""
+    monkeypatch.setattr(
+        da.ServiceInstaller, "detect_installed_unit", lambda self: None
+    )
+    _, fake_run = _fake_run_factory(is_active_stdout="")
+    monkeypatch.setattr(da.subprocess, "run", fake_run)
+
+    host.ensure_daemon_running()
+
+    assert len(sync_executor.submitted) == 1


### PR DESCRIPTION
## Summary
- Implementa `ensure_daemon_running()` em `DaemonActionsMixin` — verifica `detect_installed_unit()`, chama `systemctl --user is-active`, dispara `systemctl --user start hefesto.service` se inativo (timeout 5s, falha silenciosa)
- Invocado em thread worker antes do `show()` nos dois caminhos de `run()` — nunca bloqueia a thread GTK
- Anti-loop: máximo 2 tentativas por sessão da GUI
- Adiciona `tests/unit/test_daemon_autostart.py` (6 testes: unit não instalada, daemon já ativo, start quando inativo, anti-loop, timeout, submissão ao executor)

## Test plan
- [ ] `.venv/bin/pytest tests/unit -q` — 341 passed
- [ ] `HEFESTO_FAKE=1 HEFESTO_FAKE_TRANSPORT=usb HEFESTO_SMOKE_DURATION=2.0 ./run.sh --smoke`
- [ ] `systemctl --user stop hefesto.service && .venv/bin/python -m hefesto.app.main & sleep 6 && systemctl --user is-active hefesto.service` → active
- [ ] `./scripts/check_anonymity.sh` OK

## Ressalvas
- 8 erros mypy pré-existentes (ipc_bridge.py, status_actions.py, daemon_actions.py) — não introduzidos por esta sprint; pendentes em INFRA-MYPY-STRICT-01
- Race condition hipotética no anti-loop (burst submissions) → sprint futura INFRA-ANTILOOP-01

Closes #68