### PR TITLE
feat: Circle=Enter + Square=Esc no modo Mouse (FEAT-MOUSE-02)

### DIFF
--- a/src/hefesto/app/actions/mouse_actions.py
+++ b/src/hefesto/app/actions/mouse_actions.py
@@ -24,6 +24,8 @@ MAPPING_LEGEND = (
     "Cross (X) ou L2 → botão esquerdo\n"
     "Triangle (△) ou R2 → botão direito\n"
     "R3 (clique no analógico direito) → botão do meio\n"
+    "Circle (○) → Enter\n"
+    "Square (□) → Esc\n"
     "D-pad (↑↓←→) → setas do teclado\n"
     "Analógico esquerdo → movimento do cursor\n"
     "Analógico direito → rolagem vertical e horizontal"

--- a/src/hefesto/integrations/uinput_mouse.py
+++ b/src/hefesto/integrations/uinput_mouse.py
@@ -1,17 +1,20 @@
-"""Emulação de mouse+teclado via python-uinput a partir do DualSense (FEAT-MOUSE-01).
+"""Emulação de mouse+teclado via python-uinput a partir do DualSense (FEAT-MOUSE-01/02).
 
 Cria um device virtual uinput expondo:
   - BTN_LEFT, BTN_RIGHT, BTN_MIDDLE
   - REL_X, REL_Y (movimento) e REL_WHEEL, REL_HWHEEL (rolagem)
   - KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT (D-pad → setas)
+  - KEY_ENTER, KEY_ESC (Circle → Enter, Square → Esc — FEAT-MOUSE-02)
 
-Mapeamento canônico (FEAT-MOUSE-01, decidido pelo usuário):
+Mapeamento canônico (FEAT-MOUSE-01/02, decidido pelo usuário):
 
 | DualSense                | Saída emulada          | evdev code    |
 |--------------------------|------------------------|---------------|
 | Cross (X) ou L2          | Botão esquerdo         | BTN_LEFT      |
 | Triangle (△) ou R2       | Botão direito          | BTN_RIGHT     |
 | R3                       | Botão do meio          | BTN_MIDDLE    |
+| Circle (○)               | Enter                  | KEY_ENTER     |
+| Square (□)               | Esc                    | KEY_ESC       |
 | D-pad up/down/left/right | Setas do teclado       | KEY_*         |
 | Analógico esquerdo       | Movimento              | REL_X/REL_Y   |
 | Analógico direito        | Rolagem                | REL_WHEEL/REL_HWHEEL |
@@ -61,6 +64,14 @@ DPAD_TO_KEY: dict[str, str] = {
     "dpad_right": "KEY_RIGHT",
 }
 
+# Botões edge-triggered que emitem press+release imediatos (FEAT-MOUSE-02).
+# Circle e Square funcionam como "tecla pressionada e soltada" em cada transição
+# False→True — hold não repete. Ideal para Enter/Esc em diálogos.
+EDGE_KEY_MAP: dict[str, str] = {
+    "circle": "KEY_ENTER",
+    "square": "KEY_ESC",
+}
+
 
 def _build_capabilities() -> list[tuple[Any, ...]]:
     """Lista de eventos que o uinput device expõe. Import lazy."""
@@ -82,6 +93,8 @@ def _build_capabilities() -> list[tuple[Any, ...]]:
         uinput.KEY_DOWN,
         uinput.KEY_LEFT,
         uinput.KEY_RIGHT,
+        uinput.KEY_ENTER,
+        uinput.KEY_ESC,
     ]
     return [*rels, *buttons, *keys]
 
@@ -117,6 +130,9 @@ class UinputMouseDevice:
     _uinput_mod: Any = None
     _last_buttons_emulated: frozenset[str] = field(default_factory=frozenset)
     _last_scroll_at: float = -math.inf
+    # Estado por botão "tap" (FEAT-MOUSE-02): circle/square emitem press+release
+    # em cada transição False→True. Guarda previous_state para detectar o delta.
+    _prev_edge_keys: frozenset[str] = field(default_factory=frozenset)
 
     def start(self) -> bool:
         """Cria o device. Retorna False se /dev/uinput indisponível ou módulo ausente."""
@@ -146,6 +162,7 @@ class UinputMouseDevice:
         self._uinput_mod = None
         self._last_buttons_emulated = frozenset()
         self._last_scroll_at = -math.inf
+        self._prev_edge_keys = frozenset()
 
     def is_active(self) -> bool:
         return self._device is not None
@@ -189,9 +206,11 @@ class UinputMouseDevice:
         emulated = self._resolve_emulated_set(buttons, l2, r2)
         self._emit_buttons(emulated)
         self._emit_dpad(buttons)
+        self._emit_edge_keys(buttons)
         self._emit_move(lx, ly)
         self._emit_scroll(rx, ry, now)
         self._last_buttons_emulated = emulated
+        self._prev_edge_keys = frozenset(b for b in buttons if b in EDGE_KEY_MAP)
 
     def _resolve_emulated_set(
         self, buttons: frozenset[str], l2: int, r2: int
@@ -252,6 +271,28 @@ class UinputMouseDevice:
         if newly_pressed or newly_released:
             self._device.syn()
 
+    def _emit_edge_keys(self, buttons: frozenset[str]) -> None:
+        """Circle/Square como tap edge-triggered (FEAT-MOUSE-02).
+
+        Em cada transição False→True emite press+release imediatos da tecla
+        mapeada (KEY_ENTER/KEY_ESC). Hold do botão NÃO repete — só uma borda
+        de subida gera nova emissão.
+        """
+        u = self._uinput_mod
+        edge_now = {b for b in buttons if b in EDGE_KEY_MAP}
+        newly_pressed = edge_now - self._prev_edge_keys
+
+        if not newly_pressed:
+            return
+
+        for name in newly_pressed:
+            ev = getattr(u, EDGE_KEY_MAP[name], None)
+            if ev is None:
+                continue
+            self._device.emit(ev, 1, syn=False)
+            self._device.emit(ev, 0, syn=False)
+        self._device.syn()
+
     def _emit_move(self, lx: int, ly: int) -> None:
         """Stick esquerdo → REL_X/REL_Y com deadzone e escala."""
         dx = _compute_move(lx, self.mouse_speed)
@@ -292,6 +333,7 @@ __all__ = [
     "DEFAULT_SCROLL_SPEED",
     "DEVICE_NAME",
     "DPAD_TO_KEY",
+    "EDGE_KEY_MAP",
     "MOVE_DEADZONE",
     "SCROLL_DEADZONE",
     "SCROLL_RATE_LIMIT_SEC",

--- a/tests/unit/test_uinput_mouse.py
+++ b/tests/unit/test_uinput_mouse.py
@@ -14,6 +14,7 @@ from hefesto.integrations.uinput_mouse import (
     DEFAULT_SCROLL_SPEED,
     DEVICE_NAME,
     DPAD_TO_KEY,
+    EDGE_KEY_MAP,
     MOVE_DEADZONE,
     SCROLL_DEADZONE,
     SCROLL_RATE_LIMIT_SEC,
@@ -31,6 +32,7 @@ def _fake_uinput_module() -> MagicMock:
         "REL_X", "REL_Y", "REL_WHEEL", "REL_HWHEEL",
         "BTN_LEFT", "BTN_RIGHT", "BTN_MIDDLE",
         "KEY_UP", "KEY_DOWN", "KEY_LEFT", "KEY_RIGHT",
+        "KEY_ENTER", "KEY_ESC",
     ):
         setattr(mod, name, (1, hash(name) & 0xFFFF))
     return mod
@@ -402,6 +404,95 @@ def test_dpad_cobre_quatro_direcoes(monkeypatch: pytest.MonkeyPatch):
             buttons=frozenset(), now=t,
         )
         t += 0.2
+
+
+# --- Circle/Square edge-triggered → Enter/Esc (FEAT-MOUSE-02) ---------------
+
+def test_edge_key_map_canonico():
+    assert EDGE_KEY_MAP == {
+        "circle": "KEY_ENTER",
+        "square": "KEY_ESC",
+    }
+
+
+def test_circle_edge_trigger_enter(monkeypatch: pytest.MonkeyPatch):
+    """Circle False→True emite KEY_ENTER press+release; hold não re-emite."""
+    dev, fake_mod, fake_device = _started_device(monkeypatch)
+
+    # Primeiro tick: circle=True → press+release
+    dev.dispatch(
+        lx=128, ly=128, rx=128, ry=128, l2=0, r2=0,
+        buttons=frozenset({"circle"}), now=0.0,
+    )
+    enter = _emits_for(fake_device, fake_mod.KEY_ENTER)
+    # Emite valor 1 (press) e 0 (release) no mesmo dispatch
+    assert len(enter) == 2
+    assert enter[0][1][1] == 1
+    assert enter[1][1][1] == 0
+
+    fake_device.reset_mock()
+
+    # Segundo tick com circle=True ainda pressionado: NÃO re-emite
+    dev.dispatch(
+        lx=128, ly=128, rx=128, ry=128, l2=0, r2=0,
+        buttons=frozenset({"circle"}), now=0.05,
+    )
+    held = _emits_for(fake_device, fake_mod.KEY_ENTER)
+    assert held == []
+
+
+def test_square_edge_trigger_esc(monkeypatch: pytest.MonkeyPatch):
+    """Square False→True emite KEY_ESC press+release; hold não re-emite."""
+    dev, fake_mod, fake_device = _started_device(monkeypatch)
+
+    dev.dispatch(
+        lx=128, ly=128, rx=128, ry=128, l2=0, r2=0,
+        buttons=frozenset({"square"}), now=0.0,
+    )
+    esc = _emits_for(fake_device, fake_mod.KEY_ESC)
+    assert len(esc) == 2
+    assert esc[0][1][1] == 1
+    assert esc[1][1][1] == 0
+
+    fake_device.reset_mock()
+
+    dev.dispatch(
+        lx=128, ly=128, rx=128, ry=128, l2=0, r2=0,
+        buttons=frozenset({"square"}), now=0.05,
+    )
+    held = _emits_for(fake_device, fake_mod.KEY_ESC)
+    assert held == []
+
+
+def test_release_allows_re_emit(monkeypatch: pytest.MonkeyPatch):
+    """Após circle=False, próxima pressão re-emite KEY_ENTER."""
+    dev, fake_mod, fake_device = _started_device(monkeypatch)
+
+    # Press inicial
+    dev.dispatch(
+        lx=128, ly=128, rx=128, ry=128, l2=0, r2=0,
+        buttons=frozenset({"circle"}), now=0.0,
+    )
+    first = _emits_for(fake_device, fake_mod.KEY_ENTER)
+    assert len(first) == 2
+
+    # Release
+    dev.dispatch(
+        lx=128, ly=128, rx=128, ry=128, l2=0, r2=0,
+        buttons=frozenset(), now=0.05,
+    )
+
+    fake_device.reset_mock()
+
+    # Nova pressão: re-emite
+    dev.dispatch(
+        lx=128, ly=128, rx=128, ry=128, l2=0, r2=0,
+        buttons=frozenset({"circle"}), now=0.10,
+    )
+    second = _emits_for(fake_device, fake_mod.KEY_ENTER)
+    assert len(second) == 2
+    assert second[0][1][1] == 1
+    assert second[1][1][1] == 0
 
 
 # "A liberdade é nada mais que uma chance de ser melhor." — Albert Camus


### PR DESCRIPTION
## Summary
- `uinput_mouse.py`: `EDGE_KEY_MAP = {"circle": "KEY_ENTER", "square": "KEY_ESC"}` + `_emit_edge_keys()` edge-triggered (press+release no mesmo dispatch, syn único)
- `mouse_actions.py`: `MAPPING_LEGEND` atualizado com entradas "Circle (○) → Enter" e "Square (□) → Esc" exibidas na aba Mouse
- `_prev_edge_keys: frozenset[str]` garante emissão apenas na transição False→True (sem repetição em hold)

## Test plan
- [ ] `.venv/bin/pytest tests/unit/test_uinput_mouse.py -v` — 4 novos testes verdes
- [ ] `.venv/bin/pytest tests/unit -q` — suite completa verde
- [ ] `HEFESTO_FAKE=1 HEFESTO_FAKE_TRANSPORT=usb HEFESTO_SMOKE_DURATION=2.0 ./run.sh --smoke`
- [ ] Visual: aba Mouse mostra "Circle (○) → Enter" e "Square (□) → Esc" na legenda

Closes #87