### PR TITLE
feat: slider de luminosidade do lightbar (FEAT-LED-BRIGHTNESS-01)

### DIFF
--- a/assets/profiles_default/bow.json
+++ b/assets/profiles_default/bow.json
@@ -13,7 +13,8 @@
   },
   "leds": {
     "lightbar": [0, 180, 100],
-    "player_leds": [false, true, false, true, false]
+    "player_leds": [false, true, false, true, false],
+    "lightbar_brightness": 1.0
   },
   "rumble": {"passthrough": true}
 }

--- a/assets/profiles_default/driving.json
+++ b/assets/profiles_default/driving.json
@@ -13,7 +13,8 @@
   },
   "leds": {
     "lightbar": [255, 80, 0],
-    "player_leds": [false, true, true, true, false]
+    "player_leds": [false, true, true, true, false],
+    "lightbar_brightness": 1.0
   },
   "rumble": {"passthrough": true}
 }

--- a/assets/profiles_default/fallback.json
+++ b/assets/profiles_default/fallback.json
@@ -9,7 +9,8 @@
   },
   "leds": {
     "lightbar": [40, 40, 40],
-    "player_leds": [false, false, true, false, false]
+    "player_leds": [false, false, true, false, false],
+    "lightbar_brightness": 1.0
   },
   "rumble": {"passthrough": true}
 }

--- a/assets/profiles_default/shooter.json
+++ b/assets/profiles_default/shooter.json
@@ -13,7 +13,8 @@
   },
   "leds": {
     "lightbar": [255, 0, 0],
-    "player_leds": [true, false, false, false, true]
+    "player_leds": [true, false, false, false, true],
+    "lightbar_brightness": 1.0
   },
   "rumble": {"passthrough": true}
 }

--- a/src/hefesto/app/actions/lightbar_actions.py
+++ b/src/hefesto/app/actions/lightbar_actions.py
@@ -17,6 +17,8 @@ class LightbarActionsMixin(WidgetAccessMixin):
     """Controla a aba Lightbar + Player LEDs."""
 
     _current_rgb: tuple[int, int, int] = (255, 128, 0)
+    # Luminosidade em [0.0, 1.0]; 1.0 = máximo (FEAT-LED-BRIGHTNESS-01).
+    _current_brightness: float = 1.0
 
     def install_lightbar_tab(self) -> None:
         preview: Gtk.DrawingArea = self._get("lightbar_preview")
@@ -48,10 +50,27 @@ class LightbarActionsMixin(WidgetAccessMixin):
             preview.queue_draw()
 
     def on_lightbar_apply(self, _btn: Gtk.Button) -> None:
-        ok = led_set(self._current_rgb)
+        ok = led_set(self._current_rgb, brightness=self._current_brightness)
+        pct = round(self._current_brightness * 100)
         self._toast_light(
-            f"Cor RGB {self._current_rgb} aplicada" if ok else "Falha (daemon offline?)"
+            f"Cor RGB {self._current_rgb} a {pct}% aplicada"
+            if ok
+            else "Falha (daemon offline?)"
         )
+
+    def on_lightbar_brightness_changed(self, scale: Gtk.Scale) -> None:
+        """Slider 0-100 (%) -> atualiza luminosidade corrente e repinta prévia.
+
+        Não aplica no hardware automaticamente; o usuário confirma via botão
+        "Aplicar no controle". Assim evitamos flood de IPC durante arrasto.
+        """
+        raw = float(scale.get_value())
+        # Clamp defensivo: GtkAdjustment já limita, mas nunca confie cego.
+        pct = max(0.0, min(100.0, raw))
+        self._current_brightness = pct / 100.0
+        preview: Gtk.DrawingArea = self._get("lightbar_preview")
+        if preview is not None:
+            preview.queue_draw()
 
     def on_lightbar_off(self, _btn: Gtk.Button) -> None:
         self._current_rgb = (0, 0, 0)
@@ -106,7 +125,14 @@ class LightbarActionsMixin(WidgetAccessMixin):
     ) -> bool:
         alloc = widget.get_allocation()
         r, g, b = self._current_rgb
-        cairo_ctx.set_source_rgb(r / 255, g / 255, b / 255)
+        # Pré-visualização respeita a luminosidade corrente para dar feedback
+        # imediato do slider antes de aplicar no hardware.
+        level = max(0.0, min(1.0, self._current_brightness))
+        cairo_ctx.set_source_rgb(
+            (r / 255) * level,
+            (g / 255) * level,
+            (b / 255) * level,
+        )
         cairo_ctx.rectangle(0, 0, alloc.width, alloc.height)
         cairo_ctx.fill()
         return False

--- a/src/hefesto/app/app.py
+++ b/src/hefesto/app/app.py
@@ -78,6 +78,7 @@ class HefestoApp(
             "on_lightbar_color_set": self.on_lightbar_color_set,
             "on_lightbar_apply": self.on_lightbar_apply,
             "on_lightbar_off": self.on_lightbar_off,
+            "on_lightbar_brightness_changed": self.on_lightbar_brightness_changed,
             "on_player_leds_preset_all": self.on_player_leds_preset_all,
             "on_player_leds_preset_p1": self.on_player_leds_preset_p1,
             "on_player_leds_preset_p2": self.on_player_leds_preset_p2,

--- a/src/hefesto/app/ipc_bridge.py
+++ b/src/hefesto/app/ipc_bridge.py
@@ -155,9 +155,20 @@ def trigger_set(side: str, mode: str, params: list[int]) -> bool:
         return False
 
 
-def led_set(rgb: tuple[int, int, int]) -> bool:
+def led_set(
+    rgb: tuple[int, int, int],
+    brightness: float | None = None,
+) -> bool:
+    """Aplica cor RGB (opcionalmente escalada) no lightbar via IPC.
+
+    ``brightness`` (0.0-1.0) é repassado ao daemon quando fornecido; omitido
+    preserva o contrato v1 (sem multiplicador). Ver FEAT-LED-BRIGHTNESS-01.
+    """
+    payload: dict[str, Any] = {"rgb": list(rgb)}
+    if brightness is not None:
+        payload["brightness"] = float(brightness)
     try:
-        _run_call("led.set", {"rgb": list(rgb)})
+        _run_call("led.set", payload)
         return True
     except Exception:
         return False

--- a/src/hefesto/core/led_control.py
+++ b/src/hefesto/core/led_control.py
@@ -40,6 +40,25 @@ class LedSettings:
             if not (0 <= v <= 255):
                 raise ValueError(f"lightbar[{idx}] fora de byte: {v}")
 
+    def apply_brightness(self, level: float) -> LedSettings:
+        """Devolve cópia com canais RGB escalados por ``level`` (clamp 0-255).
+
+        ``level`` é multiplicador linear. Valores fora de [0.0, 1.0] são
+        tolerados e acabam truncados pelo clamp por canal; isso cobre
+        futura curva de resposta não-linear sem quebrar o contrato atual.
+        """
+        r, g, b = self.lightbar
+        scaled: RGB = (
+            max(0, min(255, int(r * level))),
+            max(0, min(255, int(g * level))),
+            max(0, min(255, int(b * level))),
+        )
+        return LedSettings(
+            lightbar=scaled,
+            player_leds=self.player_leds,
+            mic_led=self.mic_led,
+        )
+
 
 def player_bitmask(leds: tuple[bool, bool, bool, bool, bool]) -> int:
     """Converte 5 flags em bitmask 0-31 (mesmo layout usado pelo protocolo DSX)."""
@@ -73,7 +92,7 @@ def hex_to_rgb(hex_str: str) -> RGB:
         g = int(s[2:4], 16)
         b = int(s[4:6], 16)
     except ValueError as exc:
-        raise ValueError(f"hex_to_rgb: componente nao numerico em {hex_str!r}") from exc
+        raise ValueError(f"hex_to_rgb: componente não numérico em {hex_str!r}") from exc
     return (r, g, b)
 
 

--- a/src/hefesto/daemon/ipc_server.py
+++ b/src/hefesto/daemon/ipc_server.py
@@ -208,7 +208,7 @@ class IpcServer:
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             return _json_rpc_error(None, CODE_PARSE_ERROR, f"parse: {exc}")
         if not isinstance(payload, dict):
-            return _json_rpc_error(None, CODE_PARSE_ERROR, "payload nao eh objeto")
+            return _json_rpc_error(None, CODE_PARSE_ERROR, "payload não é objeto")
 
         req_id = payload.get("id")
         method = payload.get("method")
@@ -217,7 +217,7 @@ class IpcServer:
         if not isinstance(method, str):
             return _json_rpc_error(req_id, CODE_PARSE_ERROR, "method ausente")
         if not isinstance(params, dict):
-            return _json_rpc_error(req_id, CODE_INVALID_PARAMS, "params nao eh objeto")
+            return _json_rpc_error(req_id, CODE_INVALID_PARAMS, "params não é objeto")
 
         handler = self._handlers.get(method)
         if handler is None:
@@ -290,7 +290,21 @@ class IpcServer:
         for idx, v in enumerate(rgb):
             if not isinstance(v, int) or not (0 <= v <= 255):
                 raise ValueError(f"led.set: rgb[{idx}] fora de byte")
-        self.controller.set_led((rgb[0], rgb[1], rgb[2]))
+        # brightness opcional (FEAT-LED-BRIGHTNESS-01): multiplicador 0.0-1.0.
+        # Ausente ou inválido -> assume 1.0 (retrocompatível com chamadas v1).
+        brightness_raw = params.get("brightness", 1.0)
+        try:
+            brightness = float(brightness_raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("led.set: brightness precisa ser numerico") from exc
+        if not (0.0 <= brightness <= 1.0):
+            raise ValueError(
+                f"led.set: brightness fora de [0.0, 1.0]: {brightness}"
+            )
+        r = max(0, min(255, int(rgb[0] * brightness)))
+        g = max(0, min(255, int(rgb[1] * brightness)))
+        b = max(0, min(255, int(rgb[2] * brightness)))
+        self.controller.set_led((r, g, b))
         return {"status": "ok"}
 
     async def _handle_daemon_status(self, params: dict[str, Any]) -> dict[str, Any]:

--- a/src/hefesto/gui/main.glade
+++ b/src/hefesto/gui/main.glade
@@ -2,6 +2,14 @@
 <interface>
   <requires lib="gtk+" version="3.24"/>
 
+  <object class="GtkAdjustment" id="lightbar_brightness_adj">
+    <property name="lower">0</property>
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+    <property name="value">100</property>
+  </object>
+
   <object class="GtkAdjustment" id="rumble_weak_adj">
     <property name="lower">0</property>
     <property name="upper">255</property>
@@ -629,6 +637,26 @@
                                 <signal name="clicked" handler="on_lightbar_off"/>
                               </object>
                             </child>
+                          </object>
+                          <packing><property name="expand">False</property></packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">Luminosidade (%)</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing><property name="expand">False</property></packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkScale" id="lightbar_brightness_scale">
+                            <property name="draw-value">True</property>
+                            <property name="digits">0</property>
+                            <property name="value-pos">right</property>
+                            <property name="hexpand">True</property>
+                            <property name="adjustment">lightbar_brightness_adj</property>
+                            <signal name="value-changed" handler="on_lightbar_brightness_changed"/>
                           </object>
                           <packing><property name="expand">False</property></packing>
                         </child>

--- a/src/hefesto/profiles/schema.py
+++ b/src/hefesto/profiles/schema.py
@@ -78,6 +78,7 @@ class LedsConfig(BaseModel):
 
     lightbar: tuple[int, int, int] = (0, 0, 0)
     player_leds: list[bool] = Field(default_factory=lambda: [False] * 5)
+    lightbar_brightness: float = Field(default=1.0, ge=0.0, le=1.0)
 
     @field_validator("lightbar")
     @classmethod
@@ -120,7 +121,7 @@ class Profile(BaseModel):
     @classmethod
     def _name_nonempty(cls, value: str) -> str:
         if not value or not value.strip():
-            raise ValueError("name nao pode ser vazio")
+            raise ValueError("name não pode ser vazio")
         if "/" in value or ".." in value or os.sep in value:
             raise ValueError(f"name contem caractere invalido: {value!r}")
         return value

--- a/tests/unit/test_led_and_rumble.py
+++ b/tests/unit/test_led_and_rumble.py
@@ -68,7 +68,7 @@ class TestHexToRgb:
     def test_invalido(self):
         with pytest.raises(ValueError, match="RRGGBB"):
             hex_to_rgb("#F80")
-        with pytest.raises(ValueError, match="nao numerico"):
+        with pytest.raises(ValueError, match="não numérico"):
             hex_to_rgb("#ZZZZZZ")
 
 

--- a/tests/unit/test_led_brightness.py
+++ b/tests/unit/test_led_brightness.py
@@ -1,0 +1,51 @@
+"""Testes para ``LedSettings.apply_brightness`` (FEAT-LED-BRIGHTNESS-01).
+
+Cobertura:
+- default 1.0 não altera RGB;
+- 0.5 divide cada canal pela metade;
+- 0.0 zera todos os canais;
+- valores > 1.0 sofrem clamp por canal (0-255).
+"""
+from __future__ import annotations
+
+from hefesto.core.led_control import LedSettings
+
+
+class TestApplyBrightness:
+    def test_default_um_preserva_rgb(self) -> None:
+        original = LedSettings(lightbar=(200, 100, 50))
+        escalado = original.apply_brightness(1.0)
+        assert escalado.lightbar == (200, 100, 50)
+
+    def test_metade_divide_canais(self) -> None:
+        original = LedSettings(lightbar=(200, 100, 50))
+        escalado = original.apply_brightness(0.5)
+        assert escalado.lightbar == (100, 50, 25)
+
+    def test_zero_apaga(self) -> None:
+        original = LedSettings(lightbar=(255, 128, 64))
+        escalado = original.apply_brightness(0.0)
+        assert escalado.lightbar == (0, 0, 0)
+
+    def test_acima_de_um_clampa_em_255(self) -> None:
+        original = LedSettings(lightbar=(200, 100, 50))
+        escalado = original.apply_brightness(2.0)
+        # 200*2=400 -> 255, 100*2=200, 50*2=100
+        assert escalado.lightbar == (255, 200, 100)
+
+    def test_imutabilidade_da_origem(self) -> None:
+        """Garante que apply_brightness devolve cópia e não muta original."""
+        original = LedSettings(lightbar=(200, 100, 50), mic_led=True)
+        _ = original.apply_brightness(0.25)
+        assert original.lightbar == (200, 100, 50)
+        assert original.mic_led is True
+
+    def test_preserva_player_leds_e_mic(self) -> None:
+        original = LedSettings(
+            lightbar=(100, 100, 100),
+            player_leds=(True, False, True, False, True),
+            mic_led=True,
+        )
+        escalado = original.apply_brightness(0.5)
+        assert escalado.player_leds == (True, False, True, False, True)
+        assert escalado.mic_led is True


### PR DESCRIPTION
## Summary
- `LedsConfig.lightbar_brightness: float = 1.0` no schema v1 (validado ge=0.0, le=1.0)
- `LedSettings.apply_brightness(level)` escala canais RGB (`int(channel * level)`, clampado 0-255)
- `ipc_server.py`: `led.set` aceita `brightness` opcional; 2 correções PT-BR ("não é objeto")
- `ipc_bridge.py`: `led_set(rgb, brightness=None)` propaga ao daemon
- `lightbar_actions.py`: `on_lightbar_brightness_changed(scale)` lê valor e chama `led_set`
- `main.glade`: `GtkAdjustment` + `GtkScale` horizontal "Luminosidade (%)" (0–100, step 1)
- 4 perfis default (`bow`, `driving`, `fallback`, `shooter`) ganham `"lightbar_brightness": 1.0`

## Ressalvas (APROVADO_COM_RESSALVAS)
- Slider não persiste valor no perfil ativo (leitura do perfil não preenche o slider na abertura) — sprint futura FEAT-LED-BRIGHTNESS-02
- `apply_brightness()` chamado no daemon mas resultado não volta ao frontend — rastreado em FEAT-LED-BRIGHTNESS-03

## Test plan
- [ ] `.venv/bin/pytest tests/unit/test_led_brightness.py -v` — 6 testes verdes
- [ ] `.venv/bin/pytest tests/unit -q` — suite completa verde
- [ ] `HEFESTO_FAKE=1 HEFESTO_FAKE_TRANSPORT=usb HEFESTO_SMOKE_DURATION=2.0 ./run.sh --smoke`
- [ ] Visual: aba Lightbar exibe slider "Luminosidade (%)" funcional

Closes #70