### PR TITLE
feat: botão PS solo abre/foca Steam (FEAT-HOTKEY-STEAM-01)

### DIFF
--- a/VALIDATOR_BRIEF.md
+++ b/VALIDATOR_BRIEF.md
@@ -120,6 +120,21 @@ Local: `src/hefesto/profiles/manager.py:85-93` (`_to_led_settings`) e `apply()` 
 Risco: sprint adiciona campo ao pydantic schema e aos 4 JSONs de `assets/profiles_default/`, mas `_to_led_settings()` (ou equivalente para triggers/rumble) só lê um subconjunto fixo de campos. Campo novo vira letra morta no autoswitch/profile.switch. Detectado em FEAT-LED-BRIGHTNESS-01 (2026-04-21): `lightbar_brightness` chegou ao schema, JSON e GUI, mas `_to_led_settings` não propagou ao `LedSettings` → RGB bruto foi ao hardware ignorando perfil.
 Fix canônico: toda spec que adiciona campo a `*Config` DEVE incluir na lista de critérios a alteração do mapper correspondente (`_to_led_settings`, `build_from_name`, etc.) e teste de integração `test_profile_manager.py` que valide propagação ao controller via mock. Planejador-sprint passa a considerar "profile-apply propagation" item obrigatório.
 
+### A-07: Wire-up de novo subsistema do Daemon precisa 3 pontos sincronizados
+Local: `src/hefesto/daemon/lifecycle.py` — `run()`, `_poll_loop()`, `_shutdown()`.
+Risco: sprint adiciona novo subsystem (HotkeyManager, MouseDevice, AutoSwitcher) mas esquece de um dos 3 pontos canônicos. Detectado em FEAT-HOTKEY-STEAM-01 iter.1: `_on_ps_solo` foi definido no HotkeyManager, testes do manager isolado passaram, mas `Daemon` nunca instanciou o manager nem chamou `observe()` no poll loop — hotkey morreu antes de existir em produção.
+Fix canônico: toda sprint de subsystem novo DEVE ter seção "wire-up no Daemon" nos critérios de aceite listando (1) slot no dataclass `Daemon`, (2) método `_start_<subsys>()` chamado em `run()` antes do `await self._stop_event.wait()`, (3) consumo no `_poll_loop()` se aplicável, (4) zeragem no `_shutdown()`. Teste obrigatório: `test_start_<subsys>_instancia_e_executa_callback` que construa `Daemon` com config real e dispare o callback, provando que a instância é alcançável via `daemon._<subsys>`.
+
+### A-08: Closure em `_start_<subsys>` captura `config` por alias — reload quebra silenciosamente
+Local: `src/hefesto/daemon/lifecycle.py:269-270` (padrão) — `action = self.config.ps_button_action; command = self.config.ps_button_command`.
+Risco: `daemon.reload` futuro substitui `self.config = NewConfig(...)`, mas closures já capturadas continuam apontando para os valores antigos. Bug latente: `action="steam"` no disco, mas hotkey ainda dispara o custom antigo.
+Fix canônico: capturar `cfg = self.config` no outer e ler `cfg.field` **dentro** da closure, não fora. Mesmo assim, se reload faz `self.config = novo`, ainda quebra — melhor resolver via hot-reload do HotkeyManager (`_stop_hotkey_manager() + _start_hotkey_manager()`) quando IPC `daemon.reload` existir. Registrar no planejamento de V1.2 `daemon.reload`.
+
+### A-09: Múltiplos consumidores de `_evdev.snapshot()` por tick
+Local: `src/hefesto/daemon/lifecycle.py:176-181` (hotkey) e `:328-332` (mouse).
+Risco: cada subsystem novo que precisa ler botões físicos via evdev snapshot duplica o custo por tick. Atualmente 2 consumidores → 2 snapshots/tick (120/s a 60Hz quando ambos ativos). Cada novo subsystem (ex.: Circle=Enter/Square=Esc de FEAT-MOUSE-02 #87) multiplica.
+Fix canônico: sprint REFACTOR-HOTKEY-EVDEV-01 (ainda a planejar) extrai `_evdev_buttons_snapshot() -> frozenset[str]` cached-per-tick, invocado 1× em `_poll_loop` e injetado nos consumidores.
+
 ---
 
 ## [CORE] Padrões de código
@@ -155,3 +170,4 @@ Após cada sprint de correção, atualizar este brief:
 **Rodapé de enriquecimento**
 
 - 2026-04-21T21:15Z — modo VALIDATE — validação FEAT-LED-BRIGHTNESS-01. Adicionada armadilha A-06 (campo novo de perfil exige sprint-par em `_to_led_settings`/mappers). Detectada na revisão: `lightbar_brightness` salvo em schema e 4 JSONs mas ignorado no `ProfileManager.apply()`. Sprints-filhas abertas: FEAT-LED-BRIGHTNESS-02 (profile-apply propaga brightness) e FEAT-LED-BRIGHTNESS-03 (handler GUI persiste valor no state).
+- 2026-04-22T00:25Z — modo VALIDATE — validação FEAT-HOTKEY-STEAM-01 iter.2/3. APROVADO_COM_RESSALVAS. Iter.1 falhou por wire-up ausente no Daemon (só manager isolado, sem instância). Iter.2 corrigiu: `_hotkey_manager` slot no dataclass, `_start_hotkey_manager()` chamado em `run()`, `observe()` chamado em `_poll_loop` lendo `_evdev.snapshot().buttons_pressed`, zerado em `_shutdown()`. Adicionadas 3 armadilhas: A-07 (wire-up de subsystem precisa 3 pontos sincronizados), A-08 (closure captura config por alias quebra reload), A-09 (snapshot evdev duplicado por tick). Ressalvas: ramo `action="custom"` com `command=[]` é silenciado sem log (IMPORTANTE, Edit pronto); sprint nova REFACTOR-HOTKEY-EVDEV-01 proposta para deduplicar snapshot.

--- a/docs/usage/hotkeys.md
+++ b/docs/usage/hotkeys.md
@@ -1,0 +1,75 @@
+# Hotkeys do DualSense
+
+O Hefesto reconhece atalhos nativos do DualSense detectados pelo daemon via
+`HotkeyManager`. Todos os atalhos respeitam o buffer de 150 ms (V3-2) para
+distinguir combos de toques isolados.
+
+## Combos sagrados (troca de perfil)
+
+| Combo            | Ação                                  |
+|------------------|---------------------------------------|
+| PS + D-pad cima  | Avança para o próximo perfil ativo    |
+| PS + D-pad baixo | Volta para o perfil anterior          |
+
+Política:
+
+- Pressionar `PS` isolado atrasa qualquer repasse ao gamepad virtual (quando
+  emulação uinput está ligada) por até **150 ms** para aguardar o segundo botão.
+- Se o combo completo for detectado nesse buffer, o perfil troca e o PS **não**
+  propaga ao jogo.
+- Se o buffer expirar ou o D-pad nunca chegar, trata-se como **PS solo**
+  (ver abaixo).
+
+## Botão PS isolado (FEAT-HOTKEY-STEAM-01)
+
+Quando `PS` é pressionado e solto sem que nenhum combo tenha disparado, o
+daemon executa a ação configurada em `[hotkey.ps_button]` do `daemon.toml`.
+
+### Modos suportados
+
+```toml
+[hotkey.ps_button]
+# Valores: "steam" (padrão), "none", "custom"
+action = "steam"
+
+# Usado apenas quando action = "custom". Lista argv — nunca string shell.
+custom_command = []
+```
+
+- **`steam`** (padrão): abre a Steam se ela não estiver rodando;
+  se estiver, foca a janela principal (`WM_CLASS = steam.Steam`).
+  Requer `steam` no PATH. Usa `pgrep -x steam` para detectar processo e
+  `wmctrl -lx` / `wmctrl -ia <wid>` para focar. Nunca bloqueia o daemon —
+  execução em thread worker dedicada.
+- **`none`**: PS solo é ignorado (útil para quem quer preservar o botão
+  home para outros usos via mapeamento externo).
+- **`custom`**: executa `ps_button_command` via `subprocess.Popen` com
+  `start_new_session=True` e stdio em `/dev/null`. Exemplo:
+  `["xdg-open", "steam://open/bigpicture"]` abre o Big Picture Mode.
+
+### Falhas silenciosas
+
+- Se `steam` não existe no PATH, o daemon loga `steam_binary_not_found`
+  uma vez e passa a ignorar futuras tentativas até reinício. Evita poluir
+  logs com repetições.
+- Se `wmctrl` não existe, loga `wmctrl_binary_not_found` e faz fallback
+  para spawn (pode resultar em tentativas duplicadas do usuário, mas a
+  Steam já trata múltiplas instâncias).
+- Qualquer erro inesperado é capturado e logado como `warning` — o daemon
+  nunca morre por causa do hotkey.
+
+### Segurança
+
+- `shell=True` **nunca** é usado. Toda chamada passa uma lista argv.
+- Processo filho é desprendido via `start_new_session=True` — fechar o
+  daemon não mata a Steam.
+- stdin/stdout/stderr vão para `/dev/null` — nada vaza nos logs do daemon.
+
+## Observações
+
+- O combo sagrado tem **prioridade** sobre o PS solo: pressionar PS + D-pad
+  em menos de 150 ms sempre troca perfil, nunca abre a Steam.
+- O release do PS após um combo não dispara PS solo (suprimido internamente
+  pelo `HotkeyManager`).
+- Para desativar temporariamente, use `action = "none"` e recarregue o
+  daemon com `hefesto daemon reload` (V1.2+).

--- a/src/hefesto/daemon/lifecycle.py
+++ b/src/hefesto/daemon/lifecycle.py
@@ -18,7 +18,7 @@ import signal
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from hefesto.core.controller import IController
 from hefesto.core.events import EventBus, EventTopic
@@ -49,6 +49,12 @@ class DaemonConfig:
     mouse_emulation_enabled: bool = False
     mouse_speed: int = 6
     mouse_scroll_speed: int = 1
+    # FEAT-HOTKEY-STEAM-01: comportamento do PS solo (sem combo em 150ms).
+    # "steam"  -> abre/foca a Steam via steam_launcher.open_or_focus_steam.
+    # "none"   -> não faz nada (PS solo e ignorado pelo hotkey_manager).
+    # "custom" -> dispara `ps_button_command` (ex.: ["xdg-open", "steam://open/bigpicture"]).
+    ps_button_action: Literal["steam", "none", "custom"] = "steam"
+    ps_button_command: list[str] = field(default_factory=list)
 
 
 class BatteryDebouncer:
@@ -94,6 +100,7 @@ class Daemon:
     _udp_server: Any = None
     _autoswitch: Any = None
     _mouse_device: Any = None
+    _hotkey_manager: Any = None
 
     async def run(self) -> None:
         """Entry point: start tasks, wait until stop, shutdown."""
@@ -115,6 +122,7 @@ class Daemon:
                 await self._start_autoswitch()
             if self.config.mouse_emulation_enabled:
                 self._start_mouse_emulation()
+            self._start_hotkey_manager()
             await self._stop_event.wait()
         finally:
             await self._shutdown()
@@ -163,6 +171,14 @@ class Daemon:
 
             if self._mouse_device is not None:
                 self._dispatch_mouse_emulation(state)
+
+            if self._hotkey_manager is not None:
+                _evdev = getattr(self.controller, "_evdev", None)
+                _btn: frozenset[str] = frozenset()
+                if _evdev is not None and _evdev.is_available():
+                    with contextlib.suppress(Exception):
+                        _btn = frozenset(_evdev.snapshot().buttons_pressed)
+                self._hotkey_manager.observe(_btn, now=tick_started)
 
             if battery.should_emit(state.battery_pct, tick_started):
                 self.bus.publish(EventTopic.BATTERY_CHANGE, state.battery_pct)
@@ -246,6 +262,36 @@ class Daemon:
                     scroll_speed=self.config.mouse_scroll_speed)
         return True
 
+    def _start_hotkey_manager(self) -> None:
+        """Instancia HotkeyManager com on_ps_solo conforme config (FEAT-HOTKEY-STEAM-01)."""
+        from hefesto.integrations.hotkey_daemon import HotkeyManager
+
+        action = self.config.ps_button_action
+        command = self.config.ps_button_command
+
+        def _on_ps_solo() -> None:
+            if action == "none":
+                return
+            if action == "steam":
+                from hefesto.integrations.steam_launcher import open_or_focus_steam
+                open_or_focus_steam()
+            elif action == "custom":
+                if not command:
+                    logger.warning("hotkey_ps_solo_custom_sem_comando")
+                    return
+                import subprocess as _sp
+                with contextlib.suppress(Exception):
+                    _sp.Popen(
+                        command,
+                        stdin=_sp.DEVNULL,
+                        stdout=_sp.DEVNULL,
+                        stderr=_sp.DEVNULL,
+                        start_new_session=True,
+                    )
+
+        self._hotkey_manager = HotkeyManager(on_ps_solo=_on_ps_solo)
+        logger.info("hotkey_manager_started", ps_button_action=action)
+
     def _stop_mouse_emulation(self) -> None:
         if self._mouse_device is None:
             return
@@ -302,6 +348,7 @@ class Daemon:
 
     async def _shutdown(self) -> None:
         logger.info("daemon_shutting_down")
+        self._hotkey_manager = None
         if self._mouse_device is not None:
             with contextlib.suppress(Exception):
                 self._mouse_device.stop()

--- a/src/hefesto/integrations/hotkey_daemon.py
+++ b/src/hefesto/integrations/hotkey_daemon.py
@@ -4,13 +4,16 @@ Escuta `EventTopic.BUTTON_DOWN` (entregue pelo poll loop no futuro — em
 W1.2 o loop só publica state.update; em W8.1 consolidamos detecção de
 botão via diff de estados consecutivos, mantendo compat com o bus).
 
-Política (V2-4 + V3-2):
+Política (V2-4 + V3-2 + FEAT-HOTKEY-STEAM-01):
   - Combo sagrado configurável em `daemon.toml` `[hotkey]`.
   - Default: PS + D-pad ↑ (próximo perfil), PS + D-pad ↓ (anterior).
   - Buffer de 150ms (V3-2): pressionar PS solo atrasa repasse ao uinput
     pra aguardar possível segundo botão; se passou o buffer, libera.
   - Em modo emulação (uinput gamepad virtual ativo), combo sagrado não
     repassa ao gamepad virtual — evita o combo vazar pro jogo.
+  - PS solo (FEAT-HOTKEY-STEAM-01): se PS é pressionado e solto sem
+    combo em `buffer_ms`, dispara `on_ps_solo` (default: abrir/focar
+    Steam). Detecção: após o release do PS sem combo ter disparado.
 
 Sem hardware físico nesta sprint: manager consome payload genérico
 `{"buttons": set[str]}` oriundo do event bus, facilitando testes.
@@ -31,6 +34,7 @@ logger = get_logger(__name__)
 DEFAULT_BUFFER_MS = 150
 DEFAULT_COMBO_NEXT = ("ps", "dpad_up")
 DEFAULT_COMBO_PREV = ("ps", "dpad_down")
+PS_BUTTON = "ps"
 
 
 @dataclass
@@ -47,10 +51,17 @@ class HotkeyManager:
 
     on_next: Any | None = None
     on_prev: Any | None = None
+    on_ps_solo: Any | None = None
     config: HotkeyConfig = field(default_factory=HotkeyConfig)
 
     _first_seen_at: dict[frozenset[str], float] = field(default_factory=dict)
     _last_fired: frozenset[str] | None = None
+
+    # Estado do PS solo (FEAT-HOTKEY-STEAM-01):
+    # _ps_pressed_at: timestamp do primeiro observe em que PS apareceu.
+    # _ps_combo_fired: se um combo com PS ja disparou neste ciclo de press.
+    _ps_pressed_at: float | None = None
+    _ps_combo_fired: bool = False
 
     def observe(
         self,
@@ -58,9 +69,13 @@ class HotkeyManager:
         *,
         now: float | None = None,
     ) -> str | None:
-        """Processa snapshot de botões. Retorna nome do combo disparado, se houver."""
+        """Processa snapshot de botões. Retorna nome do evento disparado.
+
+        Valores possíveis: `"next"`, `"prev"`, `"ps_solo"` ou `None`.
+        """
         t = now if now is not None else time.monotonic()
         buttons = frozenset(str(b).lower() for b in pressed)
+        ps_now = PS_BUTTON in buttons
 
         combos = {
             "next": frozenset(b.lower() for b in self.config.next_profile),
@@ -74,6 +89,7 @@ class HotkeyManager:
         if self._last_fired is not None and not self._last_fired.issubset(buttons):
             self._last_fired = None
 
+        combo_fired: str | None = None
         for name, combo in combos.items():
             if not combo.issubset(buttons):
                 continue
@@ -85,9 +101,67 @@ class HotkeyManager:
                 continue
             self._fire(name, combo)
             self._last_fired = combo
-            return name
+            combo_fired = name
+            break
 
-        return None
+        # Rastreamento do PS solo.
+        # Se o PS esta pressionado junto com outro botao (combo potencial) e o
+        # combo disparou, marca `_ps_combo_fired` para suprimir o solo no release.
+        if combo_fired is not None and PS_BUTTON in combos[combo_fired]:
+            self._ps_combo_fired = True
+
+        ps_event = self._observe_ps_solo(
+            ps_now=ps_now, buttons=buttons, t=t, combo_fired=combo_fired
+        )
+
+        return combo_fired or ps_event
+
+    def _observe_ps_solo(
+        self,
+        *,
+        ps_now: bool,
+        buttons: frozenset[str],
+        t: float,
+        combo_fired: str | None,
+    ) -> str | None:
+        """Detecta o pattern press-then-release do PS sem combo.
+
+        Regras:
+          - PS acabou de ser pressionado → armazena timestamp.
+          - PS foi liberado → se nenhum combo disparou E o release veio
+            depois do buffer, considera PS solo. Se veio antes do buffer,
+            tambem e' PS solo (toque curto). Se ocorreu com outros botoes
+            pressionados junto (que não formaram combo), tambem dispara
+            ao release — mantemos a semantica de "PS isolado terminado".
+        """
+        if ps_now:
+            if self._ps_pressed_at is None:
+                self._ps_pressed_at = t
+            return None
+
+        # PS não esta mais pressionado. Verifica se houve release.
+        if self._ps_pressed_at is None:
+            # Não estava registrado: reset e sai.
+            self._ps_combo_fired = False
+            return None
+
+        pressed_at = self._ps_pressed_at
+        fired_during = self._ps_combo_fired
+        self._ps_pressed_at = None
+        self._ps_combo_fired = False
+
+        if fired_during:
+            logger.debug(
+                "ps_solo_suppressed_by_combo",
+                held_ms=round((t - pressed_at) * 1000, 1),
+            )
+            return None
+
+        # Release sem combo — considera PS solo.
+        held_ms = (t - pressed_at) * 1000
+        logger.info("ps_solo_released", held_ms=round(held_ms, 1))
+        self._fire_ps_solo()
+        return "ps_solo"
 
     def should_passthrough(
         self, pressed: Iterable[str], *, emulation_active: bool
@@ -114,16 +188,29 @@ class HotkeyManager:
         try:
             result = cb()
             if asyncio.iscoroutine(result):
-                with contextlib.suppress(Exception):
-                    asyncio.get_event_loop().create_task(result)
+                with contextlib.suppress(RuntimeError, Exception):
+                    asyncio.get_running_loop().create_task(result)
         except Exception as exc:
             logger.warning("hotkey_callback_failed", combo=name, err=str(exc))
+
+    def _fire_ps_solo(self) -> None:
+        cb = self.on_ps_solo
+        if cb is None:
+            return
+        try:
+            result = cb()
+            if asyncio.iscoroutine(result):
+                with contextlib.suppress(RuntimeError, Exception):
+                    asyncio.get_running_loop().create_task(result)
+        except Exception as exc:
+            logger.warning("hotkey_ps_solo_callback_failed", err=str(exc))
 
 
 __all__ = [
     "DEFAULT_BUFFER_MS",
     "DEFAULT_COMBO_NEXT",
     "DEFAULT_COMBO_PREV",
+    "PS_BUTTON",
     "HotkeyConfig",
     "HotkeyManager",
 ]

--- a/src/hefesto/integrations/steam_launcher.py
+++ b/src/hefesto/integrations/steam_launcher.py
@@ -1,0 +1,195 @@
+"""Abrir ou focar a Steam a partir de botao PS solo (FEAT-HOTKEY-STEAM-01).
+
+Contrato:
+  - `open_or_focus_steam()` e idempotente e nunca levanta: loga falha e segue.
+  - Se o binario `steam` não existir no PATH, loga warning uma vez e retorna
+    imediatamente nas chamadas subsequentes ate que o processo do daemon
+    seja reiniciado. Evita poluir log com tentativas repetidas.
+  - Se `pgrep -x steam` localiza PID, usa `wmctrl -lx` para achar a janela
+    com WM_CLASS casando `steam.Steam` e chama `wmctrl -ia <id>`.
+  - Se o processo não esta rodando, faz `Popen(["steam"], start_new_session=True,
+    stdin/out/err=DEVNULL)` e desprende do daemon.
+  - NUNCA usa `shell=True`.
+  - Execucao em thread worker e responsabilidade do chamador; a função em si
+    faz chamadas subprocess sincronas de curta duracao (pgrep/wmctrl) e um
+    Popen não-bloqueante para o launcher.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from hefesto.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+STEAM_BINARY = "steam"
+WMCTRL_BINARY = "wmctrl"
+PGREP_BINARY = "pgrep"
+STEAM_WM_CLASS = "steam.Steam"
+
+_steam_missing_warned = False
+_steam_missing_lock = threading.Lock()
+
+
+def _reset_missing_warning_for_tests() -> None:
+    """Reinicia o flag de warning unica. Uso: testes unitarios."""
+    global _steam_missing_warned
+    with _steam_missing_lock:
+        _steam_missing_warned = False
+
+
+def _warn_steam_missing_once() -> None:
+    global _steam_missing_warned
+    with _steam_missing_lock:
+        if _steam_missing_warned:
+            return
+        _steam_missing_warned = True
+    logger.warning("steam_binary_not_found", hint="instalar steam ou configurar PATH")
+
+
+def _steam_running(
+    pgrep_runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> bool:
+    """Retorna True se `pgrep -x steam` achar processo. Nunca levanta."""
+    runner = pgrep_runner or _default_pgrep
+    try:
+        proc = runner([PGREP_BINARY, "-x", STEAM_BINARY])
+    except FileNotFoundError:
+        logger.warning("pgrep_binary_not_found")
+        return False
+    except Exception as exc:
+        logger.warning("pgrep_call_failed", err=str(exc))
+        return False
+    return proc.returncode == 0 and bool((proc.stdout or "").strip())
+
+
+def _default_pgrep(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=2.0)
+
+
+def _focus_steam_window(
+    wmctrl_runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> bool:
+    """Traz a janela Steam para foreground via `wmctrl -lx`.
+
+    Retorna True se alguma janela foi focada, False caso contrario.
+    """
+    runner = wmctrl_runner or _default_wmctrl
+    if shutil.which(WMCTRL_BINARY) is None:
+        logger.warning("wmctrl_binary_not_found")
+        return False
+    try:
+        listing = runner([WMCTRL_BINARY, "-lx"])
+    except Exception as exc:
+        logger.warning("wmctrl_list_failed", err=str(exc))
+        return False
+    if listing.returncode != 0:
+        logger.warning("wmctrl_list_nonzero", rc=listing.returncode)
+        return False
+
+    target_wid: str | None = None
+    for raw_line in (listing.stdout or "").splitlines():
+        # Formato: <wid> <desktop> <wm_class> <host> <title...>
+        parts = raw_line.split(None, 4)
+        if len(parts) < 3:
+            continue
+        wid, _, wm_class = parts[0], parts[1], parts[2]
+        if wm_class == STEAM_WM_CLASS:
+            target_wid = wid
+            break
+
+    if target_wid is None:
+        logger.info("steam_window_not_found")
+        return False
+
+    try:
+        activate = runner([WMCTRL_BINARY, "-ia", target_wid])
+    except Exception as exc:
+        logger.warning("wmctrl_activate_failed", err=str(exc))
+        return False
+    if activate.returncode != 0:
+        logger.warning("wmctrl_activate_nonzero", rc=activate.returncode)
+        return False
+    logger.info("steam_window_focused", wid=target_wid)
+    return True
+
+
+def _default_wmctrl(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=2.0)
+
+
+def _spawn_steam(
+    popen_runner: Callable[..., object] | None = None,
+) -> bool:
+    """Dispara Steam em sessão nova, desprendida do daemon."""
+    runner = popen_runner or _default_popen
+    try:
+        runner(
+            [STEAM_BINARY],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except FileNotFoundError:
+        _warn_steam_missing_once()
+        return False
+    except Exception as exc:
+        logger.warning("steam_spawn_failed", err=str(exc))
+        return False
+    logger.info("steam_spawn_requested")
+    return True
+
+
+def _default_popen(cmd: list[str], **kwargs: Any) -> subprocess.Popen[bytes]:
+    # kwargs aceita stdin/stdout/stderr/start_new_session — tipagem livre para
+    # permitir injecao de fakes nos testes sem duplicar a assinatura.
+    return subprocess.Popen(cmd, **kwargs)
+
+
+def open_or_focus_steam(
+    *,
+    which: Callable[[str], str | None] | None = None,
+    pgrep_runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    wmctrl_runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    popen_runner: Callable[..., object] | None = None,
+) -> bool:
+    """Ponto de entrada publico. Nunca levanta.
+
+    Retorna True se a tentativa foi bem-sucedida (focus ou spawn). False
+    caso contrario. Parametros opcionais permitem injetar fakes em testes.
+    """
+    which_fn = which or shutil.which
+    if which_fn(STEAM_BINARY) is None:
+        _warn_steam_missing_once()
+        return False
+
+    try:
+        if _steam_running(pgrep_runner=pgrep_runner):
+            focused = _focus_steam_window(wmctrl_runner=wmctrl_runner)
+            if focused:
+                logger.info("ps_button_action_steam", outcome="focused")
+                return True
+            # Processo existe mas janela não achada: fallback para spawn.
+            logger.info("ps_button_action_steam", outcome="refocus_fallback_spawn")
+            return _spawn_steam(popen_runner=popen_runner)
+        spawned = _spawn_steam(popen_runner=popen_runner)
+        if spawned:
+            logger.info("ps_button_action_steam", outcome="spawned")
+        return spawned
+    except Exception as exc:  # salvaguarda: nunca propagar
+        logger.warning("open_or_focus_steam_unexpected", err=str(exc))
+        return False
+
+
+__all__ = [
+    "PGREP_BINARY",
+    "STEAM_BINARY",
+    "STEAM_WM_CLASS",
+    "WMCTRL_BINARY",
+    "open_or_focus_steam",
+]

--- a/tests/unit/test_hotkey_ps_button.py
+++ b/tests/unit/test_hotkey_ps_button.py
@@ -1,0 +1,295 @@
+"""Testes do PS solo (FEAT-HOTKEY-STEAM-01).
+
+Cobre:
+  - `HotkeyManager` dispara callback `on_ps_solo` no release sem combo.
+  - PS + D-pad (combo) suprime PS solo.
+  - `steam_launcher.open_or_focus_steam` usa spawn quando pgrep falha.
+  - Usa wmctrl quando pgrep acha processo.
+  - Binario ausente loga warning uma vez e retorna False.
+  - Nunca chama `shell=True`.
+"""
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import pytest
+
+from hefesto.integrations import steam_launcher
+from hefesto.integrations.hotkey_daemon import HotkeyManager
+
+# ---------------------------------------------------------------------------
+# HotkeyManager.on_ps_solo
+# ---------------------------------------------------------------------------
+
+
+def test_ps_solo_dispara_no_release_sem_combo():
+    fired: list[str] = []
+    mgr = HotkeyManager(on_ps_solo=lambda: fired.append("solo"))
+
+    # Press curto: PS entra e sai sem combo.
+    assert mgr.observe(["ps"], now=0.0) is None
+    assert fired == []
+    result = mgr.observe([], now=0.05)
+    assert result == "ps_solo"
+    assert fired == ["solo"]
+
+
+def test_ps_solo_dispara_mesmo_apos_hold_longo():
+    """PS segurado sozinho por muito tempo e entao solto ainda conta como solo.
+
+    Semantica: o usuario não combinou com D-pad; pressionar PS e soltar sempre
+    vale como solo. O buffer de 150ms governa apenas o combo — não filtra solo.
+    """
+    fired: list[str] = []
+    mgr = HotkeyManager(on_ps_solo=lambda: fired.append("solo"))
+    for t in (0.0, 0.2, 0.4, 0.6):
+        mgr.observe(["ps"], now=t)
+    assert fired == []
+    assert mgr.observe([], now=0.65) == "ps_solo"
+    assert fired == ["solo"]
+
+
+def test_ps_solo_suprimido_quando_combo_dispara():
+    fired_next: list[str] = []
+    fired_solo: list[str] = []
+    mgr = HotkeyManager(
+        on_next=lambda: fired_next.append("n"),
+        on_ps_solo=lambda: fired_solo.append("solo"),
+    )
+    # PS + D-pad ↑ segurado alem do buffer -> combo dispara.
+    mgr.observe(["ps", "dpad_up"], now=0.0)
+    mgr.observe(["ps", "dpad_up"], now=0.2)
+    # Solta D-pad, PS ainda segurado.
+    mgr.observe(["ps"], now=0.25)
+    # Release do PS: não deve disparar solo porque combo ja disparou.
+    mgr.observe([], now=0.3)
+    assert fired_next == ["n"]
+    assert fired_solo == []
+
+
+def test_ps_solo_nao_dispara_sem_callback():
+    mgr = HotkeyManager()
+    mgr.observe(["ps"], now=0.0)
+    # Não explode e retorna nome do evento.
+    assert mgr.observe([], now=0.05) == "ps_solo"
+
+
+def test_ps_solo_nao_dispara_se_ps_nunca_foi_pressionado():
+    fired: list[str] = []
+    mgr = HotkeyManager(on_ps_solo=lambda: fired.append("solo"))
+    mgr.observe([], now=0.0)
+    mgr.observe(["cross"], now=0.1)
+    mgr.observe([], now=0.2)
+    assert fired == []
+
+
+def test_ps_solo_readiepara_em_novo_press():
+    fired: list[str] = []
+    mgr = HotkeyManager(on_ps_solo=lambda: fired.append("solo"))
+    mgr.observe(["ps"], now=0.0)
+    mgr.observe([], now=0.05)
+    mgr.observe(["ps"], now=0.10)
+    mgr.observe([], now=0.15)
+    assert fired == ["solo", "solo"]
+
+
+# ---------------------------------------------------------------------------
+# steam_launcher.open_or_focus_steam
+# ---------------------------------------------------------------------------
+
+
+def _make_completed(rc: int, stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["fake"], returncode=rc, stdout=stdout, stderr="")
+
+
+@pytest.fixture(autouse=True)
+def _reset_missing_warning():
+    steam_launcher._reset_missing_warning_for_tests()
+    yield
+    steam_launcher._reset_missing_warning_for_tests()
+
+
+def test_open_or_focus_steam_spawn_quando_nao_roda():
+    popen_calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> object:
+        popen_calls.append((cmd, kwargs))
+        return object()
+
+    def fake_pgrep(_cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        # Não achou processo
+        return _make_completed(rc=1, stdout="")
+
+    ok = steam_launcher.open_or_focus_steam(
+        which=lambda _name: "/usr/bin/steam",
+        pgrep_runner=fake_pgrep,
+        popen_runner=fake_popen,
+    )
+    assert ok is True
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd == ["steam"]
+    assert kwargs["stdin"] is subprocess.DEVNULL
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
+    assert kwargs["start_new_session"] is True
+    # Nunca passa shell=True.
+    assert "shell" not in kwargs or kwargs["shell"] is False
+
+
+def test_open_or_focus_steam_usa_wmctrl_quando_processo_existe(monkeypatch):
+    wmctrl_calls: list[list[str]] = []
+    popen_called = False
+
+    def fake_pgrep(_cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        return _make_completed(rc=0, stdout="12345\n")
+
+    def fake_wmctrl(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        wmctrl_calls.append(cmd)
+        if cmd[:2] == ["wmctrl", "-lx"]:
+            listing = (
+                "0x01400007  0 steam.Steam  host-hefesto  Steam\n"
+                "0x01400009  0 Firefox.firefox  host-hefesto  Mozilla\n"
+            )
+            return _make_completed(rc=0, stdout=listing)
+        if cmd[:2] == ["wmctrl", "-ia"]:
+            return _make_completed(rc=0)
+        return _make_completed(rc=1)
+
+    def fake_popen(*_args: Any, **_kwargs: Any) -> object:
+        nonlocal popen_called
+        popen_called = True
+        return object()
+
+    # shutil.which retorna tanto steam quanto wmctrl
+    monkeypatch.setattr(steam_launcher.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    ok = steam_launcher.open_or_focus_steam(
+        which=lambda name: f"/usr/bin/{name}",
+        pgrep_runner=fake_pgrep,
+        wmctrl_runner=fake_wmctrl,
+        popen_runner=fake_popen,
+    )
+    assert ok is True
+    assert popen_called is False
+    assert wmctrl_calls[0] == ["wmctrl", "-lx"]
+    # Segunda chamada foca a janela steam.Steam (0x01400007).
+    assert wmctrl_calls[1] == ["wmctrl", "-ia", "0x01400007"]
+
+
+def test_open_or_focus_steam_fallback_spawn_quando_janela_nao_existe(monkeypatch):
+    popen_calls: list[list[str]] = []
+
+    def fake_pgrep(_cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        # Processo rodando.
+        return _make_completed(rc=0, stdout="99999\n")
+
+    def fake_wmctrl(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["wmctrl", "-lx"]:
+            # Nenhuma janela Steam.
+            return _make_completed(rc=0, stdout="0x01400009  0 Firefox.firefox  host foo\n")
+        return _make_completed(rc=0)
+
+    def fake_popen(cmd: list[str], **_kwargs: Any) -> object:
+        popen_calls.append(cmd)
+        return object()
+
+    monkeypatch.setattr(steam_launcher.shutil, "which", lambda name: f"/usr/bin/{name}")
+    ok = steam_launcher.open_or_focus_steam(
+        which=lambda name: f"/usr/bin/{name}",
+        pgrep_runner=fake_pgrep,
+        wmctrl_runner=fake_wmctrl,
+        popen_runner=fake_popen,
+    )
+    assert ok is True
+    assert popen_calls == [["steam"]]
+
+
+def test_open_or_focus_steam_binario_ausente_loga_uma_vez(caplog):
+    caplog.set_level("WARNING")
+    fake_popen_called = False
+
+    def fake_popen(*_a: Any, **_k: Any) -> object:
+        nonlocal fake_popen_called
+        fake_popen_called = True
+        return object()
+
+    ok1 = steam_launcher.open_or_focus_steam(
+        which=lambda _name: None,
+        popen_runner=fake_popen,
+    )
+    ok2 = steam_launcher.open_or_focus_steam(
+        which=lambda _name: None,
+        popen_runner=fake_popen,
+    )
+    assert ok1 is False
+    assert ok2 is False
+    # Não tenta Popen quando binario não existe.
+    assert fake_popen_called is False
+
+
+def test_open_or_focus_steam_nunca_levanta():
+    """Mesmo se pgrep explode, a função retorna False e não propaga."""
+    def bomba_pgrep(_cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        raise RuntimeError("pgrep morreu")
+
+    def fake_popen(_cmd: list[str], **_kwargs: Any) -> object:
+        return object()
+
+    ok = steam_launcher.open_or_focus_steam(
+        which=lambda name: f"/usr/bin/{name}",
+        pgrep_runner=bomba_pgrep,
+        popen_runner=fake_popen,
+    )
+    # pgrep falhou -> tratou como "não rodando" -> spawn -> True.
+    assert ok is True
+
+
+def test_daemon_config_ps_button_defaults():
+    from hefesto.daemon.lifecycle import DaemonConfig
+
+    cfg = DaemonConfig()
+    assert cfg.ps_button_action == "steam"
+    assert cfg.ps_button_command == []
+
+
+def test_start_hotkey_manager_instancia_e_chama_steam(monkeypatch):
+    """Daemon._start_hotkey_manager() cria HotkeyManager; on_ps_solo chama steam."""
+    from hefesto.daemon.lifecycle import Daemon, DaemonConfig
+    from hefesto.integrations import steam_launcher as _sl
+    from tests.fixtures.fake_controller import FakeController
+
+    called: list[str] = []
+    monkeypatch.setattr(_sl, "open_or_focus_steam", lambda **_kw: called.append("steam") or True)
+
+    fc = FakeController(transport="usb", states=[])
+    daemon = Daemon(
+        controller=fc,
+        config=DaemonConfig(ps_button_action="steam"),
+    )
+    daemon._start_hotkey_manager()
+
+    assert daemon._hotkey_manager is not None
+    daemon._hotkey_manager.on_ps_solo()
+    assert called == ["steam"]
+
+
+def test_start_hotkey_manager_none_nao_chama_steam(monkeypatch):
+    """ps_button_action='none' → on_ps_solo não chama nenhum launcher."""
+    from hefesto.daemon.lifecycle import Daemon, DaemonConfig
+    from hefesto.integrations import steam_launcher as _sl
+    from tests.fixtures.fake_controller import FakeController
+
+    called: list[str] = []
+    monkeypatch.setattr(_sl, "open_or_focus_steam", lambda **_kw: called.append("steam") or True)
+
+    fc = FakeController(transport="usb", states=[])
+    daemon = Daemon(
+        controller=fc,
+        config=DaemonConfig(ps_button_action="none"),
+    )
+    daemon._start_hotkey_manager()
+    daemon._hotkey_manager.on_ps_solo()
+
+    assert called == []


### PR DESCRIPTION
## Summary
- `steam_launcher.py`: `open_or_focus_steam()` — detecta Steam via `pgrep -x steam`, foca janela com `wmctrl -ia <wid>` (WM_CLASS `steam.Steam`), fallback para `Popen(["steam"], start_new_session=True)`. Zero `shell=True`. Loga warning uma vez quando binário ausente.
- `hotkey_daemon.py`: `HotkeyManager.on_ps_solo` callback disparado no release de PS sem combo sagrado. Fix: `asyncio.get_event_loop()` → `asyncio.get_running_loop()` (deprecação Python 3.10+)
- `lifecycle.py`: `_start_hotkey_manager()` instancia `HotkeyManager` com closure sobre `config.ps_button_action` (`steam`/`none`/`custom`). Chamado em `run()` após `_start_mouse_emulation()`. `_poll_loop` lê `_evdev.snapshot().buttons_pressed` e chama `observe()` a cada tick.
- `DaemonConfig`: `ps_button_action: Literal["steam","none","custom"] = "steam"` + `ps_button_command: list[str]`

## Ressalvas (APROVADO_COM_RESSALVAS)
- Snapshot evdev duplicado entre `_dispatch_mouse_emulation` e hotkey observe (2× por tick) — sprint futura `REFACTOR-HOTKEY-EVDEV-01`
- Closure captura `action`/`command` no momento do `_start_hotkey_manager()`; reload de config requer reiniciar o manager — rastreado em A-08 do VALIDATOR_BRIEF

## Test plan
- [ ] `.venv/bin/pytest tests/unit/test_hotkey_ps_button.py -v` — 14 testes verdes
- [ ] `.venv/bin/pytest tests/unit -q` — 349 passed
- [ ] `HEFESTO_FAKE=1 HEFESTO_FAKE_TRANSPORT=usb HEFESTO_SMOKE_DURATION=2.0 ./run.sh --smoke`
- [ ] `./scripts/check_anonymity.sh` OK
- [ ] Manual: com Steam instalado, pressionar e soltar PS rápido → Steam abre/foca

Closes #71