### PR TITLE
chore: acentuação PT-BR em ipc_server + run.sh (CHORE-ACENTO-01)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
 if [[ ! -d .venv ]]; then
-    echo "erro: .venv/ nao encontrado. Rode ./scripts/dev_bootstrap.sh primeiro."
+    echo "erro: .venv/ não encontrado. Rode ./scripts/dev_bootstrap.sh primeiro."
     exit 1
 fi
 # shellcheck disable=SC1091
@@ -87,4 +87,4 @@ fi
 
 exec hefesto daemon start --foreground
 
-# "Faca o pequeno bem que esta proximo." — Tolstoi
+# "Faça o pequeno bem que está próximo." — Tolstói

--- a/src/hefesto/daemon/ipc_server.py
+++ b/src/hefesto/daemon/ipc_server.py
@@ -208,7 +208,7 @@ class IpcServer:
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             return _json_rpc_error(None, CODE_PARSE_ERROR, f"parse: {exc}")
         if not isinstance(payload, dict):
-            return _json_rpc_error(None, CODE_PARSE_ERROR, "payload nao eh objeto")
+            return _json_rpc_error(None, CODE_PARSE_ERROR, "payload não é objeto")
 
         req_id = payload.get("id")
         method = payload.get("method")
@@ -217,7 +217,7 @@ class IpcServer:
         if not isinstance(method, str):
             return _json_rpc_error(req_id, CODE_PARSE_ERROR, "method ausente")
         if not isinstance(params, dict):
-            return _json_rpc_error(req_id, CODE_INVALID_PARAMS, "params nao eh objeto")
+            return _json_rpc_error(req_id, CODE_INVALID_PARAMS, "params não é objeto")
 
         handler = self._handlers.get(method)
         if handler is None:


### PR DESCRIPTION
## Summary
- `ipc_server.py`: `"payload nao eh objeto"` → `"payload não é objeto"` e `"params nao eh objeto"` → `"params não é objeto"`
- `run.sh`: `"nao encontrado"` → `"não encontrado"` e citação `"proximo"` → `"próximo"` (Tolstói)

## Test plan
- [ ] `.venv/bin/pytest tests/unit -q` — 335 passed
- [ ] `./scripts/check_anonymity.sh` OK

Closes #77