### PR TITLE
feat(triggers): exportar/importar preset standalone (FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01)

### DIFF
--- a/docs/process/sprints/FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01.md
+++ b/docs/process/sprints/FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01.md
@@ -1,0 +1,442 @@
+# FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01 — Exportar/Importar preset de gatilho como JSON standalone
+
+**Tipo:** feature (GUI + IO de arquivo + schema novo).
+**Wave:** V2.5 — sprint #8 da ordem recomendada em `docs/process/SPRINT_ORDER.md:445`.
+**Porte:** S.
+**Estimativa:** 1 iteração.
+**Dependências:** FEAT-PROFILE-STATE-01 (`DraftConfig` central), FEAT-RUMBLE-PER-PROFILE-OVERRIDE-01 (MERGED 2026-04-24, baseline 1340 testes).
+
+---
+
+**Tracking:** label `type:feature`, `gui`, `triggers`, `profiles`, `ai-task`, `status:ready`.
+
+## Objetivo
+
+Adicionar 2 botões na aba **Gatilhos** da GUI GTK3 (um por coluna L2/R2 ou um par compartilhado) que permitem ao usuário **exportar** o estado atual do editor de gatilho selecionado para um arquivo `.json` standalone e **importar** um arquivo `.json` standalone repondo o estado do editor (sem commitar — usuário ainda precisa "Aplicar em L2/R2" para enviar via IPC e "Salvar perfil" no rodapé para persistir).
+
+Uso esperado: um usuário cria um gatilho `MultiPositionFeedback` calibrado fino, exporta para `meu_gatilho_arco.json`, compartilha em fórum/Discord; outro usuário importa via GUI e tem o mesmo comportamento sem precisar redigitar 10 sliders.
+
+## Contexto
+
+Estado atual (2026-04-24, HEAD `main` pós FEAT-RUMBLE-PER-PROFILE-OVERRIDE-01 merged), confirmado via leitura linha-a-linha:
+
+- `src/hefesto/gui/main.glade:392-614` — aba Gatilhos é um `GtkBox` horizontal `tab_triggers_box` com 2 colunas (`GtkFrame` "L2 (gatilho esquerdo)" e "R2 (gatilho direito)"). Cada coluna tem layout vertical: `trigger_<side>_mode` (combo modo) → `trigger_<side>_preset_row` (linha de preset por posição, com `trigger_<side>_preset_combo`) → `trigger_<side>_desc` (label) → `GtkScrolledWindow` com `trigger_<side>_params_box` (sliders dinâmicos) → linha de 2 botões `trigger_<side>_apply` ("Aplicar em L2/R2") + `trigger_<side>_reset` ("Desligar (Off)"). A linha 617 fecha o `tab_triggers_box` e a tab tem label "Gatilhos" via `GtkLabel`. **Não existe rodapé extra** na aba — os 2 botões novos vão **dentro de cada coluna**, abaixo da linha apply/reset, ou em uma nova linha horizontal compartilhada entre as duas colunas. Decisão tomada na seção Escopo abaixo.
+- `src/hefesto/app/actions/triggers_actions.py` (341L) — `TriggersActionsMixin` é o mixin canônico para handlers da aba. Usa `WidgetAccessMixin._get(...)`, mantém `self.draft` (instância imutável de `DraftConfig`) e `self._trigger_param_widgets[side][param_name]` (dict de `Gtk.Scale`). Já há padrão de `_collect_values(side)` (lê sliders → dict `{name: int}`) e `_apply_trigger(side)` (commita IPC + atualiza draft). Reusar esses helpers.
+- `src/hefesto/profiles/schema.py:64-118` — `TriggerConfig(mode: str, params: list[int] | list[list[int]])` + `TriggersConfig(left: TriggerConfig, right: TriggerConfig)`. Validador `_validate_params` rejeita mistura `[[1,2], 3]`. Ambos com `model_config = ConfigDict(extra="forbid")`. Re-uso direto: o que importa para o preset standalone é **um único** `TriggerConfig` (lado único), não o par. Schema novo `TriggerPreset` será wrapper com metadados + um `TriggerConfig`.
+- `src/hefesto/profiles/trigger_presets.py:1-125` — namespace **diferente** do que esta sprint adiciona. Esse arquivo expõe `FEEDBACK_POSITION_PRESETS` / `VIBRATION_POSITION_PRESETS` (presets internos hardcoded de 10 posições para o combo "Preset por posição"). **Não confundir**: a sprint nova é IO de arquivo do usuário, schema dedicado, módulo novo `trigger_preset_io.py`. Comentário explícito vai no docstring do módulo novo apontando essa diferença para evitar fusão errada na próxima refatoração.
+- `src/hefesto/app/actions/footer_actions.py:170-256` — padrão canônico de `FileChooserDialog` no projeto: `Gtk.FileChooserDialog` + `Gtk.FileChooserAction.OPEN/SAVE`, filtro `*.json`, ler com `json.loads(Path(...).read_text("utf-8"))`, validar com `Profile.model_validate`, em erro chamar `self._footer_toast(f"Arquivo inválido: {exc}")` + `logger.warning(...)`. **Reusar exato esse padrão**, adaptando `Profile` → `TriggerPreset`.
+- `src/hefesto/app/actions/firmware_actions.py:105-110` — também usa `FileChooserDialog`. Confirma que o padrão estabelecido no projeto é `FileChooserDialog`, **não** `FileChooserNative`. Sprint segue `FileChooserDialog` para consistência (mesmo que o prompt original tenha sugerido `Native`).
+- `src/hefesto/app/draft_config.py:32-47` — `TriggerDraft(mode: str, params: tuple[int, ...])` (frozen) + `TriggersDraft(left, right)`. **Round-trip alvo**: editor → snapshot atual de sliders → exportar → reimportar → popular sliders idênticos. O draft do trigger no lado importado é atualizado via `self.draft.model_copy(update={"triggers": new_triggers})` no padrão já estabelecido em `_on_mode_changed` (linha 130) e `_apply_trigger` (linha 292-293).
+- `src/hefesto/app/app.py:148-220` — `_signal_handlers()` registra **explicitamente** todos os handlers do builder (`on_trigger_left_*`, `on_firmware_*`, etc.). Armadilha A-7-ish recorrente: handler novo no glade sem entrada em `_signal_handlers()` → botão morto silenciosamente. Documentado em `BUG-FIRMWARE-SIGNAL-HANDLERS-01` (PR 77.1, MERGED). Spec exige adicionar handlers ao dict.
+- `assets/profiles_default/fps.json` — referência do formato canônico de `triggers.left/right` em JSON: `{"mode": "Rigid", "params": [0, 255]}` para shape simples; presets multi-posição usam `params: [[…], …]` aninhado. O preset standalone exporta o **mesmo shape** dentro de um wrapper.
+- `tests/unit/test_triggers_actions.py` (existente) — base para testes do mixin com mocks GTK; padrão `pytest` + `unittest.mock.MagicMock` para `Gtk.ComboBoxText`. Reusar como template dos novos casos.
+- Baseline pytest 2026-04-24 HEAD `main`: **1340 testes coletados**.
+
+L-21-3 aplicada: spec foi escrito **após** leitura completa de `main.glade` (linhas 390-620), `triggers_actions.py` (1-341), `schema.py` (1-220), `trigger_presets.py` (1-125), `draft_config.py` (1-200), `footer_actions.py` (170-260), `app.py` (130-220) e amostras `assets/profiles_default/*.json`.
+
+Premissas do prompt original que **divergiram do código real**, ajustadas no spec:
+
+- Prompt sugeriu `GtkFileChooserNative` — projeto usa **`FileChooserDialog`** em `footer_actions.py` e `firmware_actions.py`; sprint segue o padrão estabelecido.
+- Prompt sugeriu `src/hefesto/app/actions/trigger_actions.py` (singular) — caminho real é `triggers_actions.py` (plural). Ajustado.
+- Prompt sugeriu reusar `manager.py::load_profile/save_profile` — esses são para **perfil inteiro**; sprint cria funções **dedicadas** `export_trigger_preset`/`import_trigger_preset` no novo módulo `trigger_preset_io.py`. Justificativa: schema diferente (`TriggerPreset` é wrapper de um `TriggerConfig`, não Profile completo).
+- Prompt sugeriu campo novo em `TriggersConfig` — **não é necessário**. Schema do preset standalone é arquivo separado; o `TriggersConfig` do `Profile` permanece intocado. Sprint **não dispara A-06** (não adiciona campo a `LedsConfig/TriggersConfig/RumbleConfig` consumido por mapper de perfil).
+
+## Escopo
+
+### Decisão 1 — Schema novo `TriggerPreset` com wrapper de metadados
+
+Criar **novo arquivo** `src/hefesto/profiles/trigger_preset_schema.py` com:
+
+```python
+from __future__ import annotations
+from datetime import UTC, datetime
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from hefesto.profiles.schema import TriggerConfig
+
+SCHEMA_VERSION = 1
+
+
+class TriggerPreset(BaseModel):
+    """Preset standalone exportável de um único gatilho (L2 ou R2).
+
+    Diferença vs. ``trigger_presets.py`` (sem 'io' no nome):
+        - ``trigger_presets.py``: dicionários hardcoded de 10 intensidades por
+          posição, internos ao app, não vão para arquivo do usuário.
+        - Este módulo: wrapper JSON exportável/importável pelo usuário via GUI,
+          carrega metadados (versão, timestamp, nome legível) + um TriggerConfig.
+
+    Estrutura JSON canônica:
+        {
+          "schema_version": 1,
+          "name": "Arco bow precisão",
+          "exported_at": "2026-04-24T12:34:56+00:00",
+          "trigger": {"mode": "MultiPositionFeedback", "params": [...]}
+        }
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=SCHEMA_VERSION)
+    name: str = Field(min_length=1, max_length=120)
+    exported_at: str  # ISO8601 com offset, sem precisão sub-segundo
+    trigger: TriggerConfig
+
+    @field_validator("schema_version")
+    @classmethod
+    def _check_version(cls, value: int) -> int:
+        if value != SCHEMA_VERSION:
+            raise ValueError(
+                f"schema_version não suportado: {value} (esperado {SCHEMA_VERSION})"
+            )
+        return value
+
+    @field_validator("exported_at")
+    @classmethod
+    def _check_timestamp(cls, value: str) -> str:
+        # Aceita ISO8601 com ou sem fração; rejeita string vazia.
+        if not value:
+            raise ValueError("exported_at vazio")
+        try:
+            datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(f"exported_at não é ISO8601: {value}") from exc
+        return value
+
+
+__all__ = ["SCHEMA_VERSION", "TriggerPreset"]
+```
+
+**Justificativa do wrapper (não exportar `TriggerConfig` puro):**
+
+1. Versionamento explícito permite migração futura sem quebrar arquivos antigos.
+2. Nome legível ajuda o usuário a identificar o arquivo (filename pode ter sido renomeado).
+3. Timestamp dá pistas de origem e ordem cronológica em coleções de presets.
+4. Espaço para crescer (campos opcionais no futuro: `author`, `description`, `tags`) sem quebrar contrato.
+
+### Decisão 2 — Módulo IO `trigger_preset_io.py`
+
+Criar **novo arquivo** `src/hefesto/profiles/trigger_preset_io.py`:
+
+```python
+from __future__ import annotations
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from hefesto.profiles.schema import TriggerConfig
+from hefesto.profiles.trigger_preset_schema import SCHEMA_VERSION, TriggerPreset
+
+
+def export_trigger_preset(
+    path: Path,
+    *,
+    name: str,
+    trigger: TriggerConfig,
+) -> Path:
+    """Serializa ``trigger`` como TriggerPreset JSON em ``path``.
+
+    Atomic write via tempfile + rename, espelhando padrão de save_profile.
+    Retorna o Path final (idêntico ao argumento, validado).
+    """
+    preset = TriggerPreset(
+        schema_version=SCHEMA_VERSION,
+        name=name,
+        exported_at=datetime.now(UTC).isoformat(timespec="seconds"),
+        trigger=trigger,
+    )
+    payload = preset.model_dump(mode="json")
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=False)
+
+    path = Path(path)
+    if path.suffix != ".json":
+        path = path.with_suffix(".json")
+
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(text + "\n", encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def import_trigger_preset(path: Path) -> TriggerPreset:
+    """Lê e valida JSON em ``path`` retornando TriggerPreset.
+
+    Levanta:
+        FileNotFoundError: arquivo inexistente.
+        json.JSONDecodeError: JSON malformado.
+        pydantic.ValidationError: schema/validação rejeitou.
+    """
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    return TriggerPreset.model_validate(raw)
+```
+
+Padrão de erro: **não engolir exceção dentro do módulo IO**. Quem chama (handler GTK) decide formato da mensagem ao usuário.
+
+### Decisão 3 — Layout dos botões no glade
+
+**Decisão escolhida: 1 botão de cada lado, dentro de cada coluna L2/R2.**
+
+Razão:
+- Mantém simetria visual (cada coluna é autônoma).
+- Usuário sabe exatamente qual lado está sendo exportado (não precisa de combo extra "qual lado?").
+- Implementação simples: handlers separados `on_trigger_left_preset_export`, `on_trigger_left_preset_import`, idem `right`.
+
+Em cada coluna, **abaixo** da linha existente apply/reset (após `</packing></child>` da linha 498/606 no glade), adicionar nova `GtkBox` horizontal com 2 botões:
+
+```xml
+<child>
+  <object class="GtkBox">
+    <property name="orientation">horizontal</property>
+    <property name="spacing">8</property>
+    <property name="homogeneous">True</property>
+    <property name="margin-top">4</property>
+    <child>
+      <object class="GtkButton" id="trigger_left_preset_export">
+        <property name="label">Exportar preset...</property>
+        <property name="tooltip-text">Salva o estado atual do editor L2 em arquivo JSON</property>
+        <signal name="clicked" handler="on_trigger_left_preset_export"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="trigger_left_preset_import">
+        <property name="label">Importar preset...</property>
+        <property name="tooltip-text">Carrega arquivo JSON e popula o editor L2 (não aplica)</property>
+        <signal name="clicked" handler="on_trigger_left_preset_import"/>
+      </object>
+    </child>
+  </object>
+  <packing><property name="expand">False</property></packing>
+</child>
+```
+
+Mesmo bloco espelhado para `right` (IDs `trigger_right_preset_export`, `trigger_right_preset_import`, handlers idem).
+
+**Acentuação obrigatória**: labels e tooltips com `á/é/í/ó/ú/â/ê/ô/ã/õ/ç` corretos onde aplicável (ex. "Não aplica" deve ser "Não" — confirmar codificação UTF-8 ao salvar o glade).
+
+### Decisão 4 — Handlers no `TriggersActionsMixin`
+
+Adicionar em `src/hefesto/app/actions/triggers_actions.py`:
+
+```python
+def on_trigger_left_preset_export(self, _btn: Gtk.Button) -> None:
+    self._handle_preset_export("left")
+
+def on_trigger_right_preset_export(self, _btn: Gtk.Button) -> None:
+    self._handle_preset_export("right")
+
+def on_trigger_left_preset_import(self, _btn: Gtk.Button) -> None:
+    self._handle_preset_import("left")
+
+def on_trigger_right_preset_import(self, _btn: Gtk.Button) -> None:
+    self._handle_preset_import("right")
+
+def _handle_preset_export(self, side: str) -> None:
+    """Coleta estado atual do editor (modo + params dos sliders), pede nome
+    e caminho ao usuário, grava arquivo JSON. Não toca daemon nem perfil."""
+    # 1. Coletar TriggerConfig do editor:
+    #    - mode = combo trigger_<side>_mode.get_active_id()
+    #    - params = self._collect_values(side) reformatado para list[int] ou
+    #      list[list[int]] dependendo do modo (reusar lógica de _send_trigger_named).
+    # 2. Pedir nome legível via gui_dialogs.prompt_profile_name(parent, default_name=f"trigger_{side}").
+    # 3. Pedir caminho via Gtk.FileChooserDialog SAVE com filtro *.json.
+    # 4. Chamar export_trigger_preset(path, name=nome, trigger=cfg).
+    # 5. Toast de sucesso ou erro via self._toast_trigger(side, "export", ok).
+
+def _handle_preset_import(self, side: str) -> None:
+    """Pede arquivo, valida, popula widgets sem commitar IPC."""
+    # 1. Gtk.FileChooserDialog OPEN com filtro *.json.
+    # 2. import_trigger_preset(path) → TriggerPreset.
+    # 3. Em erro de json/pydantic: self._toast_trigger(side, f"importar falhou: {exc}", False).
+    #    Não alterar widgets nem draft.
+    # 4. Em sucesso: setar combo trigger_<side>_mode.set_active_id(preset.trigger.mode);
+    #    chamar self._rebuild_params(side, mode); restaurar valores nos sliders.
+    #    Atualizar self.draft.triggers.<side> = TriggerDraft(mode, params=tuple(...)).
+    # 5. NÃO chamar trigger_set (IPC) — usuário ainda precisa "Aplicar em L2/R2".
+    # 6. Toast: "Preset importado em <SIDE>. Pressione 'Aplicar em <SIDE>' para enviar."
+```
+
+**Detalhe crítico** sobre `params` aninhados: modos `MultiPositionFeedback`/`MultiPositionVibration` têm `params: list[list[int]]`. Em `triggers_actions.py:269-271` o `_collect_values` retorna `dict[str, int]` (sliders flat). A **reconversão para shape canônico** é feita por `preset_to_factory_args` em `trigger_specs.py` — reusar essa função no export, e na importação, fazer o caminho inverso (preset.trigger.params → repopular sliders). Spec exige executor inspecionar `trigger_specs.py:preset_to_factory_args` e documentar a inversão no commit.
+
+### Decisão 5 — Registro em `_signal_handlers`
+
+Adicionar em `src/hefesto/app/app.py:148-220`, na seção "Triggers":
+
+```python
+"on_trigger_left_preset_export": self.on_trigger_left_preset_export,
+"on_trigger_right_preset_export": self.on_trigger_right_preset_export,
+"on_trigger_left_preset_import": self.on_trigger_left_preset_import,
+"on_trigger_right_preset_import": self.on_trigger_right_preset_import,
+```
+
+**Armadilha herdada de `BUG-FIRMWARE-SIGNAL-HANDLERS-01`**: handler no glade sem entrada nesse dict = botão morto silencioso. Validação visual obrigatória clica nos botões para flagrar essa regressão.
+
+### Restrições
+
+- **NÃO tocar** `assets/profiles_default/*.json` — feature é GUI + IO standalone.
+- **NÃO tocar** `src/hefesto/daemon/**` — sem alterações em IPC, schema do daemon, lifecycle.
+- **NÃO criar** dependência nova em `pyproject.toml` — toda a feature usa stdlib + pydantic já presente.
+- **NÃO importar** de `hefesto.daemon.*` em `trigger_preset_schema.py` ou `trigger_preset_io.py` (regra de camadas).
+- **NÃO chamar** `trigger_set` (IPC) durante import — usuário aplica explicitamente. Invariante: import é não-destrutivo até "Aplicar em L2/R2" ser pressionado.
+- **NÃO sobrescrever** outros campos do draft (LEDs, rumble, mouse, key_bindings) — só `triggers.<side>`.
+
+## Arquivos tocados
+
+**Criar:**
+- `src/hefesto/profiles/trigger_preset_schema.py` (~50 linhas).
+- `src/hefesto/profiles/trigger_preset_io.py` (~60 linhas).
+- `tests/unit/test_trigger_preset_io.py` (~120 linhas, 5+ testes).
+- `tests/unit/test_triggers_actions_preset_io.py` (~100 linhas, 4+ testes com mocks GTK).
+
+**Modificar:**
+- `src/hefesto/gui/main.glade` — 2 blocos `<child>` com par de botões (1 por coluna). +~30 linhas.
+- `src/hefesto/app/actions/triggers_actions.py` — 4 handlers + 2 helpers privados (`_handle_preset_export`, `_handle_preset_import`). +~80 linhas.
+- `src/hefesto/app/app.py:148-220` — 4 entradas no dict `_signal_handlers()`.
+
+**Não tocar (invariante):**
+- `assets/profiles_default/**`.
+- `src/hefesto/daemon/**`.
+- `src/hefesto/profiles/manager.py`, `loader.py`, `schema.py`, `trigger_presets.py`, `autoswitch.py`.
+- `src/hefesto/core/**`.
+
+## Critérios de aceite
+
+1. `src/hefesto/gui/main.glade` ganha 4 GtkButton novos com IDs `trigger_left_preset_export`, `trigger_left_preset_import`, `trigger_right_preset_export`, `trigger_right_preset_import`. Labels PT-BR exatos: `"Exportar preset..."` e `"Importar preset..."` (com reticências triplas, tooltip explicando comportamento).
+2. Handlers `on_trigger_<side>_preset_export` e `on_trigger_<side>_preset_import` **registrados em `_signal_handlers()` de `app.py`**. Validador roda smoke visual e clica nos 4 botões — nenhum gera "no handler defined" no journal/stderr.
+3. `TriggerPreset.model_validate` aceita JSON válido (`schema_version=1`, `name` não-vazio, `exported_at` ISO8601 válido, `trigger` é `TriggerConfig` válido).
+4. **Round-trip puro (sem GTK):** `cfg = TriggerConfig(mode="Rigid", params=[0, 255])` → `export_trigger_preset(p, name="x", trigger=cfg)` → `import_trigger_preset(p).trigger == cfg`. Idem para shape aninhado `mode="MultiPositionFeedback", params=[[0,1,2,...], ...]`.
+5. **JSON malformado** (string `"{invalido"`) ao chamar `import_trigger_preset` levanta `json.JSONDecodeError`. Handler GUI captura e mostra toast `"Arquivo inválido: ..."` PT-BR. Nem widgets nem `self.draft` mudam.
+6. **Schema rejeitado** (ex.: `schema_version=999`) ao chamar `import_trigger_preset` levanta `pydantic.ValidationError`. Handler GUI captura e mostra toast.
+7. **Import bem-sucedido NÃO chama `trigger_set` (IPC).** Teste com mock de `trigger_set` confirma 0 invocações durante import. `self.draft.triggers.<side>` reflete o preset; `self.draft.triggers.<outro_lado>` permanece intacto.
+8. **Export atomic write**: `export_trigger_preset` grava em `path.with_suffix(".json.tmp")` e faz `replace(path)`. Teste injeta exceção entre `write_text` e `replace`; arquivo final não é criado/sobrescrito.
+9. Pytest sobe de **1340 → 1349** ou mais (≥9 novos testes). Suite completa passa: `1349 passed / 8 skipped` (skipped count herdado).
+10. `ruff check src/ tests/` e `mypy src/hefesto` passam (mypy file count +1 ou +2 conforme arquivos novos com type hints completos).
+11. **Acentuação periférica**: varredura `rg "funcao|validacao|configuracao|comunicacao|descricao|operacao|gravacao|exportacao|importacao|persiste"` nos arquivos tocados retorna zero. Especialmente `"importação"` e `"exportação"` com til.
+12. **Validação visual obrigatória** (toca `main.glade`): validador-sprint auto-invoca skill `validacao-visual` e gera 2 PNGs (antes do fix sem botões + depois com botões na aba Gatilhos). Comando canônico do BRIEF (com `WID="Hefesto v"`) registrado no PR junto com sha256 dos PNGs.
+13. **Sem emojis gráficos** nos labels/tooltips/toasts (Emoji_Presentation block proibido). Glifos Unicode de estado (●/○/▼) permitidos se já existirem na aba.
+
+## Aritmética e baseline
+
+- `triggers_actions.py` atual: 341 linhas. Crescimento estimado: +80L → ~421L. Sem violar nenhum teto (não há sprint de redução de tamanho ativa para esse arquivo).
+- `main.glade` atual: 2300 linhas. +~30L → ~2330L. Sem teto.
+- `app.py` atual: ~250L (seção `_signal_handlers`). +4L. Sem teto.
+- Pytest baseline: **FAIL_BEFORE = 0** (1340 passed). Esperado **FAIL_AFTER = 0** (1349+ passed). Skipped permanece em 8.
+- Mypy files: 113 atual → 114 ou 115 (+1 schema, +1 io). Erros: 0 → 0.
+
+## Plano de implementação
+
+1. **Criar schema** `src/hefesto/profiles/trigger_preset_schema.py` com `TriggerPreset` + constante `SCHEMA_VERSION`.
+2. **Criar IO** `src/hefesto/profiles/trigger_preset_io.py` com `export_trigger_preset` + `import_trigger_preset`.
+3. **Testes unit do IO** em `tests/unit/test_trigger_preset_io.py`:
+   - `test_round_trip_simples` (mode=Rigid, params=[0,255]).
+   - `test_round_trip_aninhado` (mode=MultiPositionFeedback, params=[[…],…]).
+   - `test_export_normaliza_extensao` (path sem `.json` ganha sufixo).
+   - `test_export_atomic_write` (tmpfile + replace).
+   - `test_import_json_malformado_levanta_decodeerror`.
+   - `test_import_schema_version_invalido_levanta_validation`.
+   - `test_import_name_vazio_levanta_validation`.
+   - `test_import_exported_at_invalido_levanta_validation`.
+   - `test_import_trigger_extra_field_levanta_validation` (`extra="forbid"`).
+4. **Glade**: adicionar 2 blocos de `GtkBox` (1 por coluna L2/R2), cada um com 2 botões. Confirmar UTF-8 BOM-less.
+5. **Mixin**: adicionar 4 handlers públicos + 2 privados em `triggers_actions.py`. Reusar `_collect_values`, `preset_to_factory_args`, `_rebuild_params`. Para reconverter `dict[str,int]` em `list[int]` ou `list[list[int]]` no export, espelhar a lógica de `_send_trigger_named` (linhas 304-322).
+6. **`app.py`**: adicionar 4 entradas no dict `_signal_handlers()`.
+7. **Testes do mixin** em `tests/unit/test_triggers_actions_preset_io.py`:
+   - `test_handle_preset_import_atualiza_draft_sem_chamar_ipc` (mock `trigger_set`).
+   - `test_handle_preset_import_arquivo_invalido_nao_altera_draft`.
+   - `test_handle_preset_import_outro_lado_intocado` (importa em `left` → `right` permanece).
+   - `test_handle_preset_export_grava_arquivo_com_estado_dos_sliders` (mock chooser, mock filesystem).
+8. **Lint + types**: `ruff check src/ tests/` e `mypy src/hefesto`.
+9. **Smoke USB + BT** (2s cada) — proof-of-work runtime.
+10. **Validação visual**: `.venv/bin/python -m hefesto.app.main`, navegar à aba Gatilhos, capturar PNG antes (sem botões — só se executor preservar baseline pré-mudança) e depois (com botões), sha256.
+11. **Acentuação periférica**: `rg` nos arquivos tocados.
+
+## Testes obrigatórios
+
+### Unit IO (sem GTK)
+
+```python
+# tests/unit/test_trigger_preset_io.py
+def test_round_trip_simples(tmp_path):
+    cfg = TriggerConfig(mode="Rigid", params=[0, 255])
+    p = export_trigger_preset(tmp_path / "rigid.json", name="Rigid teste", trigger=cfg)
+    preset = import_trigger_preset(p)
+    assert preset.trigger == cfg
+    assert preset.name == "Rigid teste"
+    assert preset.schema_version == 1
+```
+
+Repetir para shape aninhado, JSON malformado, schema_version errado, name vazio, exported_at inválido, extra field.
+
+### Unit mixin (com mocks GTK)
+
+Reusar fixtures de `tests/unit/test_triggers_actions.py`. Mockar `Gtk.FileChooserDialog.run/get_filename/destroy`, `gui_dialogs.prompt_profile_name`, e `trigger_set`. Asserts:
+- `trigger_set.assert_not_called()` em import.
+- `mixin.draft.triggers.left.mode == "Rigid"` após import válido em `left`.
+- `mixin.draft.triggers.right == previous_right` (intocado).
+
+## Proof-of-work esperado
+
+Runtime real (comandos canônicos do BRIEF):
+
+```bash
+# Setup (idempotente)
+bash scripts/dev-setup.sh
+
+# Smoke USB
+HEFESTO_FAKE=1 HEFESTO_FAKE_TRANSPORT=usb HEFESTO_SMOKE_DURATION=2.0 ./run.sh --smoke
+
+# Smoke BT
+HEFESTO_FAKE=1 HEFESTO_FAKE_TRANSPORT=bt HEFESTO_SMOKE_DURATION=2.0 ./run.sh --smoke --bt
+
+# Suite
+.venv/bin/pytest tests/unit -v --no-header -q
+
+# Lint + types
+.venv/bin/ruff check src/ tests/
+.venv/bin/mypy src/hefesto
+
+# Anonimato
+./scripts/check_anonymity.sh
+```
+
+Validação visual (skill `validacao-visual`, A-12 — usa `.venv/bin/python` com PyGObject; se ausente, fallback do BRIEF):
+
+```bash
+.venv/bin/python -m hefesto.app.main &
+sleep 3
+WID=$(xdotool search --name "Hefesto v" | head -1)
+TS=$(date +%Y%m%dT%H%M%S)
+xdotool windowactivate "$WID" && sleep 0.4
+# Navegar à aba Gatilhos manualmente ou via xdotool key
+import -window "$WID" "/tmp/hefesto_gui_triggers_preset_io_${TS}.png"
+sha256sum "/tmp/hefesto_gui_triggers_preset_io_${TS}.png"
+```
+
+PR deve incluir:
+- Diff completo (Edit-only, zero Write em arquivos pré-existentes).
+- Output de pytest com contagem 1349+/8.
+- Output de ruff + mypy zerados.
+- 2 PNGs (antes/depois) + sha256.
+- Descrição multimodal da validação visual: "Aba Gatilhos exibe duas colunas L2/R2 com 4 sliders de modo + linha de botões 'Aplicar / Desligar' + nova linha 'Exportar preset... / Importar preset...'. Acentuação correta. Contraste preservado."
+- Hipótese verificada: `rg "TriggerPreset"` confirma instâncias só nos novos módulos + testes.
+
+## Riscos e não-objetivos
+
+**Riscos conhecidos:**
+- `gi`/`Gtk` ausente no `.venv` (A-12 PARCIAL). Mitigação: validador roda smoke + testes; visual cai no fallback do BRIEF se PyGObject ausente.
+- Modos com `params` aninhado podem ter conversão errada (sliders flat vs `list[list[int]]`). Mitigação: testes de round-trip explícitos para `MultiPositionFeedback` e `MultiPositionVibration`, espelhando `_send_trigger_named`.
+- Usuário pode tentar importar arquivo `Profile.json` (perfil completo) confundindo com preset standalone. Mitigação: schema com `extra="forbid"` rejeita imediatamente; toast PT-BR cita `"name"`/`"trigger"` ausentes.
+
+**Não-objetivos** (registrar como sprint nova se aparecerem):
+- Compartilhar **pacote** com múltiplos presets (ex.: zip de 4 gatilhos). Próxima sprint se houver demanda.
+- Importar **direto no perfil ativo** sem passar pelo editor. Quebra invariante "import é não-destrutivo".
+- Auto-aplicar via IPC após import. Usuário deve apertar "Aplicar em L2/R2".
+- I18N dos toasts/labels — virá em `FEAT-I18N-01` (item 7 da Wave V2.5).
+- Browser/galeria de presets compartilhados (cloud) — fora do escopo do MVP.
+
+## Referências
+
+- BRIEF: `/home/andrefarias/Desenvolvimento/Hefesto-DualSense_Unix/VALIDATOR_BRIEF.md` (seções `[CORE] Contratos de runtime`, `[CORE] Capacidades visuais`, A-06, A-12).
+- SPRINT_ORDER: `docs/process/SPRINT_ORDER.md:445` (item 8 Wave V2.5).
+- Precedente histórico de FileChooser + validação pydantic: `BUG-FIRMWARE-SIGNAL-HANDLERS-01` (PR 77.1, 2026-04 MERGED) + `src/hefesto/app/actions/footer_actions.py:170-256`.
+- Precedente histórico de schema standalone com wrapper de metadados: pydantic `Profile` em `src/hefesto/profiles/schema.py:187-220`.
+- Lições aplicadas: L-21-3 (leitura código antes de spec), L-21-4 (proof-of-work runtime real), L-21-7 (aritmética explícita).

--- a/src/hefesto/app/actions/triggers_actions.py
+++ b/src/hefesto/app/actions/triggers_actions.py
@@ -2,7 +2,9 @@
 # ruff: noqa: E402
 from __future__ import annotations
 
-from typing import Any
+import json
+from pathlib import Path
+from typing import Any, cast
 
 import gi
 
@@ -17,12 +19,20 @@ from hefesto.app.actions.trigger_specs import (
     preset_to_factory_args,
 )
 from hefesto.app.ipc_bridge import trigger_set
+from hefesto.profiles.schema import TriggerConfig
+from hefesto.profiles.trigger_preset_io import (
+    export_trigger_preset,
+    import_trigger_preset,
+)
 from hefesto.profiles.trigger_presets import (
     FEEDBACK_POSITION_LABELS,
     VIBRATION_POSITION_LABELS,
     resolve_feedback_preset,
     resolve_vibration_preset,
 )
+from hefesto.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 class TriggersActionsMixin(WidgetAccessMixin):
@@ -109,6 +119,20 @@ class TriggersActionsMixin(WidgetAccessMixin):
 
     def on_trigger_right_reset(self, _btn: Gtk.Button) -> None:
         self._reset_trigger("right")
+
+    # --- preset IO (FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01) ---
+
+    def on_trigger_left_preset_export(self, _btn: Gtk.Button) -> None:
+        self._handle_preset_export("left")
+
+    def on_trigger_right_preset_export(self, _btn: Gtk.Button) -> None:
+        self._handle_preset_export("right")
+
+    def on_trigger_left_preset_import(self, _btn: Gtk.Button) -> None:
+        self._handle_preset_import("left")
+
+    def on_trigger_right_preset_import(self, _btn: Gtk.Button) -> None:
+        self._handle_preset_import("right")
 
     # --- helpers ---
 
@@ -339,3 +363,277 @@ class TriggersActionsMixin(WidgetAccessMixin):
             else f"{side.upper()} -> {preset_id} falhou (daemon offline?)"
         )
         bar.push(ctx_id, msg)
+
+    # --- preset IO helpers ---
+
+    def _toast_preset_io(self, side: str, msg: str) -> None:
+        """Empurra mensagem para a status_bar (canal dedicado a preset IO)."""
+        bar: Any = self._get("status_bar")
+        if bar is None:
+            return
+        ctx_id = bar.get_context_id("trigger_preset_io")
+        bar.push(ctx_id, f"{side.upper()} -> {msg}")
+
+    def _build_trigger_config_for_export(self, side: str) -> TriggerConfig | None:
+        """Coleta o estado atual do editor (modo + sliders) como ``TriggerConfig``.
+
+        Reusa ``preset_to_factory_args`` para reconverter ``dict[str, int]``
+        em ``list[int]`` (modos simples) ou ``list[list[int]]`` (modos
+        ``MultiPosition*``). Para ``Custom``, achata em ``[mode, *forces]``.
+        Retorna ``None`` se modo é desconhecido ou ``Off`` (nada a exportar).
+        """
+        combo: Gtk.ComboBoxText | None = self._get(f"trigger_{side}_mode")
+        if combo is None:
+            return None
+        preset_id = combo.get_active_id()
+        if preset_id is None:
+            return None
+        spec = get_spec(preset_id)
+        if spec is None:
+            return None
+
+        values = self._collect_values(side)
+        args = preset_to_factory_args(spec, values)
+
+        params: list[int] | list[list[int]]
+        if isinstance(args, list):
+            params = list(args)
+        elif preset_id == "MultiPositionFeedback":
+            strengths_obj = args.get("strengths", []) if isinstance(args, dict) else []
+            strengths = (
+                list(strengths_obj)
+                if isinstance(strengths_obj, (list, tuple))
+                else []
+            )
+            params = [list(strengths)]
+        elif preset_id == "MultiPositionVibration":
+            if isinstance(args, dict):
+                freq = int(cast(Any, args.get("frequency", 0)) or 0)
+                strengths_obj = args.get("strengths", [])
+            else:
+                freq = 0
+                strengths_obj = []
+            strengths = (
+                list(strengths_obj)
+                if isinstance(strengths_obj, (list, tuple))
+                else []
+            )
+            params = [[freq], list(strengths)]
+        elif preset_id == "Custom":
+            if isinstance(args, dict):
+                mode_val = int(cast(Any, args.get("mode", 0)) or 0)
+                forces_obj = args.get("forces", ())
+            else:
+                mode_val = 0
+                forces_obj = ()
+            forces = (
+                list(forces_obj)
+                if isinstance(forces_obj, (list, tuple))
+                else []
+            )
+            params = [mode_val, *forces]
+        else:
+            params = []
+
+        return TriggerConfig(mode=preset_id, params=params)
+
+    def _handle_preset_export(self, side: str) -> None:
+        """Exporta o estado do editor ``side`` para arquivo JSON via FileChooser.
+
+        Não toca o daemon nem o draft. Usuário escolhe nome legível
+        (default ``trigger_<side>``) e caminho. Erros são reportados via
+        toast PT-BR.
+        """
+        cfg = self._build_trigger_config_for_export(side)
+        if cfg is None:
+            self._toast_preset_io(side, "exportar: nenhum modo válido selecionado")
+            return
+
+        from hefesto.app import gui_dialogs
+
+        window = self._get("main_window")
+        nome = gui_dialogs.prompt_profile_name(
+            parent=window, default_name=f"trigger_{side}"
+        )
+        if not nome:
+            self._toast_preset_io(side, "exportar cancelado")
+            return
+
+        chooser = Gtk.FileChooserDialog(
+            title="Exportar preset de gatilho",
+            parent=window,
+            action=Gtk.FileChooserAction.SAVE,
+        )
+        chooser.add_button("Cancelar", Gtk.ResponseType.CANCEL)
+        chooser.add_button("Salvar", Gtk.ResponseType.OK)
+        chooser.set_default_response(Gtk.ResponseType.OK)
+        chooser.set_do_overwrite_confirmation(True)
+        chooser.set_current_name(f"{nome}.json")
+
+        filtro = Gtk.FileFilter()
+        filtro.set_name("Presets JSON (*.json)")
+        filtro.add_pattern("*.json")
+        chooser.add_filter(filtro)
+
+        response = chooser.run()
+        filename = chooser.get_filename()
+        chooser.destroy()
+
+        if response != Gtk.ResponseType.OK or not filename:
+            self._toast_preset_io(side, "exportar cancelado")
+            return
+
+        try:
+            final_path = export_trigger_preset(
+                Path(filename), name=nome, trigger=cfg
+            )
+        except OSError as exc:
+            self._toast_preset_io(side, f"falha ao gravar: {exc}")
+            logger.warning(
+                "trigger_preset_export_falhou",
+                side=side,
+                arquivo=filename,
+                erro=str(exc),
+            )
+            return
+
+        self._toast_preset_io(side, f"preset exportado em {final_path}")
+        logger.info(
+            "trigger_preset_export_ok",
+            side=side,
+            arquivo=str(final_path),
+            nome=nome,
+            modo=cfg.mode,
+        )
+
+    def _handle_preset_import(self, side: str) -> None:
+        """Importa preset JSON e popula o editor de ``side`` sem aplicar via IPC.
+
+        Usuário precisa pressionar "Aplicar em <SIDE>" para enviar o estado
+        ao daemon. Outro lado (L2/R2) permanece intocado.
+        """
+        window = self._get("main_window")
+
+        chooser = Gtk.FileChooserDialog(
+            title="Importar preset de gatilho",
+            parent=window,
+            action=Gtk.FileChooserAction.OPEN,
+        )
+        chooser.add_button("Cancelar", Gtk.ResponseType.CANCEL)
+        chooser.add_button("Abrir", Gtk.ResponseType.OK)
+        chooser.set_default_response(Gtk.ResponseType.OK)
+
+        filtro = Gtk.FileFilter()
+        filtro.set_name("Presets JSON (*.json)")
+        filtro.add_pattern("*.json")
+        chooser.add_filter(filtro)
+
+        response = chooser.run()
+        filename = chooser.get_filename()
+        chooser.destroy()
+
+        if response != Gtk.ResponseType.OK or not filename:
+            self._toast_preset_io(side, "importar cancelado")
+            return
+
+        try:
+            preset = import_trigger_preset(Path(filename))
+        except FileNotFoundError as exc:
+            self._toast_preset_io(side, f"arquivo não encontrado: {exc}")
+            logger.warning(
+                "trigger_preset_import_inexistente",
+                side=side,
+                arquivo=filename,
+                erro=str(exc),
+            )
+            return
+        except json.JSONDecodeError as exc:
+            self._toast_preset_io(side, f"arquivo inválido: {exc}")
+            logger.warning(
+                "trigger_preset_import_json_invalido",
+                side=side,
+                arquivo=filename,
+                erro=str(exc),
+            )
+            return
+        except Exception as exc:
+            # Validation error e demais — preservar comportamento "não altera widgets".
+            self._toast_preset_io(side, f"arquivo inválido: {exc}")
+            logger.warning(
+                "trigger_preset_import_validacao_falhou",  # log key ASCII por convenção structlog
+                side=side,
+                arquivo=filename,
+                erro=str(exc),
+            )
+            return
+
+        # Popular widgets sem disparar IPC.
+        self._apply_imported_preset_to_editor(side, preset.trigger)
+        self._toast_preset_io(
+            side,
+            f"preset '{preset.name}' importado. Pressione 'Aplicar em "
+            f"{side.upper()}' para enviar.",
+        )
+        logger.info(
+            "trigger_preset_import_ok",
+            side=side,
+            arquivo=filename,
+            nome=preset.name,
+            modo=preset.trigger.mode,
+        )
+
+    def _apply_imported_preset_to_editor(
+        self, side: str, trigger: TriggerConfig
+    ) -> None:
+        """Repopula combo de modo + sliders + draft a partir de ``TriggerConfig``.
+
+        NÃO chama ``trigger_set`` (IPC). Usuário ainda precisa pressionar
+        "Aplicar em L2/R2" para enviar ao daemon. Apenas o lado ``side`` é
+        afetado; o outro permanece intocado em ``self.draft``.
+        """
+        from hefesto.app.draft_config import TriggerDraft
+
+        combo: Gtk.ComboBoxText | None = self._get(f"trigger_{side}_mode")
+        if combo is None:
+            return
+
+        # Reconstrói widgets dinâmicos do modo importado (com guard para não
+        # disparar handlers de signal recursivamente).
+        self._guard_refresh = True
+        try:
+            combo.set_active_id(trigger.mode)
+            self._rebuild_params(side, trigger.mode)
+            self._update_preset_row_visibility(side, trigger.mode)
+
+            # Achatar params para a sequência ordenada de sliders.
+            flat: list[int] = []
+            if trigger.is_nested:
+                for sub in trigger.params:
+                    if isinstance(sub, list):
+                        flat.extend(int(x) for x in sub)
+            else:
+                flat = [int(cast(Any, x)) for x in trigger.params]
+
+            widgets = self._trigger_param_widgets.get(side, {})
+            for idx, name in enumerate(widgets):
+                if idx < len(flat):
+                    widgets[name].set_value(flat[idx])
+        finally:
+            self._guard_refresh = False
+
+        # Atualiza draft do lado importado preservando o outro.
+        draft = getattr(self, "draft", None)
+        if draft is not None:
+            params_tuple: tuple[int, ...]
+            if trigger.is_nested:
+                acc: list[int] = []
+                for sub in trigger.params:
+                    if isinstance(sub, list):
+                        acc.extend(int(x) for x in sub)
+                params_tuple = tuple(acc)
+            else:
+                params_tuple = tuple(int(cast(Any, x)) for x in trigger.params)
+
+            new_trigger = TriggerDraft(mode=trigger.mode, params=params_tuple)
+            new_triggers = draft.triggers.model_copy(update={side: new_trigger})
+            self.draft = draft.model_copy(update={"triggers": new_triggers})

--- a/src/hefesto/app/app.py
+++ b/src/hefesto/app/app.py
@@ -157,6 +157,10 @@ class HefestoApp(
             "on_trigger_right_apply": self.on_trigger_right_apply,
             "on_trigger_left_reset": self.on_trigger_left_reset,
             "on_trigger_right_reset": self.on_trigger_right_reset,
+            "on_trigger_left_preset_export": self.on_trigger_left_preset_export,
+            "on_trigger_right_preset_export": self.on_trigger_right_preset_export,
+            "on_trigger_left_preset_import": self.on_trigger_left_preset_import,
+            "on_trigger_right_preset_import": self.on_trigger_right_preset_import,
             # Lightbar + Player LEDs
             "on_lightbar_color_set": self.on_lightbar_color_set,
             "on_lightbar_apply": self.on_lightbar_apply,

--- a/src/hefesto/gui/main.glade
+++ b/src/hefesto/gui/main.glade
@@ -497,6 +497,30 @@
                           </object>
                           <packing><property name="expand">False</property></packing>
                         </child>
+
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">horizontal</property>
+                            <property name="spacing">8</property>
+                            <property name="homogeneous">True</property>
+                            <property name="margin-top">4</property>
+                            <child>
+                              <object class="GtkButton" id="trigger_left_preset_export">
+                                <property name="label">Exportar preset...</property>
+                                <property name="tooltip-text">Salva o estado atual do editor L2 em arquivo JSON</property>
+                                <signal name="clicked" handler="on_trigger_left_preset_export"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="trigger_left_preset_import">
+                                <property name="label">Importar preset...</property>
+                                <property name="tooltip-text">Carrega arquivo JSON e popula o editor L2 (não aplica)</property>
+                                <signal name="clicked" handler="on_trigger_left_preset_import"/>
+                              </object>
+                            </child>
+                          </object>
+                          <packing><property name="expand">False</property></packing>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -600,6 +624,30 @@
                               <object class="GtkButton" id="trigger_right_reset">
                                 <property name="label">Desligar (Off)</property>
                                 <signal name="clicked" handler="on_trigger_right_reset"/>
+                              </object>
+                            </child>
+                          </object>
+                          <packing><property name="expand">False</property></packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">horizontal</property>
+                            <property name="spacing">8</property>
+                            <property name="homogeneous">True</property>
+                            <property name="margin-top">4</property>
+                            <child>
+                              <object class="GtkButton" id="trigger_right_preset_export">
+                                <property name="label">Exportar preset...</property>
+                                <property name="tooltip-text">Salva o estado atual do editor R2 em arquivo JSON</property>
+                                <signal name="clicked" handler="on_trigger_right_preset_export"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="trigger_right_preset_import">
+                                <property name="label">Importar preset...</property>
+                                <property name="tooltip-text">Carrega arquivo JSON e popula o editor R2 (não aplica)</property>
+                                <signal name="clicked" handler="on_trigger_right_preset_import"/>
                               </object>
                             </child>
                           </object>

--- a/src/hefesto/gui/main.glade
+++ b/src/hefesto/gui/main.glade
@@ -506,15 +506,15 @@
                             <property name="margin-top">4</property>
                             <child>
                               <object class="GtkButton" id="trigger_left_preset_export">
-                                <property name="label">Exportar preset...</property>
-                                <property name="tooltip-text">Salva o estado atual do editor L2 em arquivo JSON</property>
+                                <property name="label">Exportar...</property>
+                                <property name="tooltip-text">Salva o estado atual do editor L2 em arquivo JSON (preset standalone)</property>
                                 <signal name="clicked" handler="on_trigger_left_preset_export"/>
                               </object>
                             </child>
                             <child>
                               <object class="GtkButton" id="trigger_left_preset_import">
-                                <property name="label">Importar preset...</property>
-                                <property name="tooltip-text">Carrega arquivo JSON e popula o editor L2 (não aplica)</property>
+                                <property name="label">Importar...</property>
+                                <property name="tooltip-text">Carrega preset JSON e popula o editor L2 (não aplica nem salva)</property>
                                 <signal name="clicked" handler="on_trigger_left_preset_import"/>
                               </object>
                             </child>
@@ -638,15 +638,15 @@
                             <property name="margin-top">4</property>
                             <child>
                               <object class="GtkButton" id="trigger_right_preset_export">
-                                <property name="label">Exportar preset...</property>
-                                <property name="tooltip-text">Salva o estado atual do editor R2 em arquivo JSON</property>
+                                <property name="label">Exportar...</property>
+                                <property name="tooltip-text">Salva o estado atual do editor R2 em arquivo JSON (preset standalone)</property>
                                 <signal name="clicked" handler="on_trigger_right_preset_export"/>
                               </object>
                             </child>
                             <child>
                               <object class="GtkButton" id="trigger_right_preset_import">
-                                <property name="label">Importar preset...</property>
-                                <property name="tooltip-text">Carrega arquivo JSON e popula o editor R2 (não aplica)</property>
+                                <property name="label">Importar...</property>
+                                <property name="tooltip-text">Carrega preset JSON e popula o editor R2 (não aplica nem salva)</property>
                                 <signal name="clicked" handler="on_trigger_right_preset_import"/>
                               </object>
                             </child>

--- a/src/hefesto/profiles/trigger_preset_io.py
+++ b/src/hefesto/profiles/trigger_preset_io.py
@@ -1,0 +1,73 @@
+"""IO de presets standalone de gatilho (FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01).
+
+Funções utilitárias puras (sem GTK, sem IPC) para serializar e desserializar
+um ``TriggerPreset`` em arquivo ``.json``.
+
+Atomic write via ``tempfile + replace``, espelhando o padrão de
+``hefesto.profiles.manager.save_profile``: grava em ``<path>.tmp``, depois
+renomeia para ``<path>``. Falha entre os dois passos não corrompe o arquivo
+final.
+
+Não engole exceções — quem chama (handler GTK ou teste) decide o formato
+da mensagem ao usuário.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hefesto.profiles.schema import TriggerConfig
+from hefesto.profiles.trigger_preset_schema import SCHEMA_VERSION, TriggerPreset
+
+
+def export_trigger_preset(
+    path: Path | str,
+    *,
+    name: str,
+    trigger: TriggerConfig,
+) -> Path:
+    """Serializa ``trigger`` como ``TriggerPreset`` JSON em ``path``.
+
+    Garante extensão ``.json``: se o caminho recebido tiver extensão diferente
+    ou ausente, troca/adiciona ``.json`` antes de gravar.
+
+    Atomic write: escreve em ``<final>.tmp`` e usa ``Path.replace`` para
+    posicionar o arquivo final. Se a escrita do tmp falhar, o arquivo final
+    não é tocado.
+
+    Retorna o ``Path`` final (validado e com sufixo correto).
+    """
+    preset = TriggerPreset(
+        schema_version=SCHEMA_VERSION,
+        name=name,
+        exported_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        trigger=trigger,
+    )
+    payload = preset.model_dump(mode="json")
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=False)
+
+    final_path = Path(path)
+    if final_path.suffix != ".json":
+        final_path = final_path.with_suffix(".json")
+
+    tmp_path = final_path.with_suffix(".json.tmp")
+    tmp_path.write_text(text + "\n", encoding="utf-8")
+    tmp_path.replace(final_path)
+    return final_path
+
+
+def import_trigger_preset(path: Path | str) -> TriggerPreset:
+    """Lê e valida JSON em ``path`` retornando ``TriggerPreset``.
+
+    Levanta:
+        FileNotFoundError: arquivo inexistente.
+        json.JSONDecodeError: JSON malformado.
+        pydantic.ValidationError: schema rejeitou (campo ausente, valor
+            inválido, ``schema_version`` desconhecida, ``extra="forbid"``).
+    """
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    return TriggerPreset.model_validate(raw)
+
+
+__all__ = ["export_trigger_preset", "import_trigger_preset"]

--- a/src/hefesto/profiles/trigger_preset_schema.py
+++ b/src/hefesto/profiles/trigger_preset_schema.py
@@ -1,0 +1,76 @@
+"""Schema standalone de preset de gatilho exportável (FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01).
+
+Diferença em relação a ``trigger_presets.py`` (sem sufixo ``_schema``):
+
+- ``trigger_presets.py``: dicionários hardcoded de 10 intensidades por
+  posição (``FEEDBACK_POSITION_PRESETS`` / ``VIBRATION_POSITION_PRESETS``).
+  São presets internos do app, usados pelo combo "Preset por posição"
+  da aba Gatilhos. Nunca vão a arquivo do usuário.
+- Este módulo (``trigger_preset_schema.py``): wrapper JSON
+  exportável/importável pelo usuário via GUI. Carrega metadados
+  (versão, timestamp, nome legível) + um único ``TriggerConfig``.
+
+Formato canônico em disco::
+
+    {
+      "schema_version": 1,
+      "name": "Arco bow precisão",
+      "exported_at": "2026-04-24T12:34:56+00:00",
+      "trigger": {"mode": "MultiPositionFeedback", "params": [...]}
+    }
+
+Compat de migração: ``schema_version`` é validado de forma estrita.
+Quando o formato evoluir, a versão sobe e ``_check_version`` ganha
+ramo de upcast a partir do número antigo.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from hefesto.profiles.schema import TriggerConfig
+
+SCHEMA_VERSION = 1
+
+
+class TriggerPreset(BaseModel):
+    """Preset standalone exportável de um único gatilho (L2 ou R2)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=SCHEMA_VERSION)
+    name: str = Field(min_length=1, max_length=120)
+    exported_at: str
+    trigger: TriggerConfig
+
+    @field_validator("schema_version")
+    @classmethod
+    def _check_version(cls, value: int) -> int:
+        if value != SCHEMA_VERSION:
+            raise ValueError(
+                f"schema_version não suportado: {value} (esperado {SCHEMA_VERSION})"
+            )
+        return value
+
+    @field_validator("exported_at")
+    @classmethod
+    def _check_timestamp(cls, value: str) -> str:
+        if not value:
+            raise ValueError("exported_at vazio")
+        try:
+            datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(f"exported_at não é ISO8601: {value}") from exc
+        return value
+
+    @field_validator("name")
+    @classmethod
+    def _strip_name(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("name vazio após strip")
+        return stripped
+
+
+__all__ = ["SCHEMA_VERSION", "TriggerPreset"]

--- a/tests/unit/test_trigger_preset_io.py
+++ b/tests/unit/test_trigger_preset_io.py
@@ -1,0 +1,189 @@
+"""Testes unitários do IO standalone de preset de gatilho.
+
+FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01.
+
+Cobertura:
+  - Round-trip simples (Rigid).
+  - Round-trip aninhado (MultiPositionFeedback com ``params: list[list[int]]``).
+  - Normalização de extensão (path sem ``.json`` ganha sufixo).
+  - Escrita atômica (tmp + replace) — falha entre tmp e replace não cria final.
+  - JSON malformado levanta ``json.JSONDecodeError``.
+  - schema_version inválido levanta ``ValidationError``.
+  - name vazio levanta ``ValidationError``.
+  - exported_at malformado levanta ``ValidationError``.
+  - extra field levanta ``ValidationError`` (``extra="forbid"``).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from hefesto.profiles.schema import TriggerConfig
+from hefesto.profiles.trigger_preset_io import (
+    export_trigger_preset,
+    import_trigger_preset,
+)
+from hefesto.profiles.trigger_preset_schema import SCHEMA_VERSION, TriggerPreset
+
+
+def test_round_trip_simples(tmp_path: Path) -> None:
+    cfg = TriggerConfig(mode="Rigid", params=[0, 255])
+    final = export_trigger_preset(tmp_path / "rigid.json", name="Rigid teste", trigger=cfg)
+    assert final.exists()
+    preset = import_trigger_preset(final)
+    assert preset.trigger == cfg
+    assert preset.name == "Rigid teste"
+    assert preset.schema_version == SCHEMA_VERSION
+
+
+def test_round_trip_aninhado(tmp_path: Path) -> None:
+    nested = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 0]]
+    cfg = TriggerConfig(mode="MultiPositionFeedback", params=nested)
+    final = export_trigger_preset(
+        tmp_path / "multipos.json", name="Multi pos arco", trigger=cfg
+    )
+    preset = import_trigger_preset(final)
+    assert preset.trigger.mode == "MultiPositionFeedback"
+    assert preset.trigger.params == nested
+    assert preset.trigger.is_nested is True
+
+
+def test_export_normaliza_extensao(tmp_path: Path) -> None:
+    cfg = TriggerConfig(mode="Off", params=[])
+    final = export_trigger_preset(tmp_path / "sem_extensao", name="Off", trigger=cfg)
+    assert final.suffix == ".json"
+    assert final.name == "sem_extensao.json"
+    assert final.exists()
+
+
+def test_export_substitui_extensao_nao_json(tmp_path: Path) -> None:
+    cfg = TriggerConfig(mode="Off", params=[])
+    final = export_trigger_preset(tmp_path / "preset.txt", name="Off", trigger=cfg)
+    assert final.suffix == ".json"
+    assert final.exists()
+
+
+def test_export_atomic_write_tmp_nao_persiste(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Se ``replace`` falha, ``<final>`` original não é sobrescrito."""
+    cfg = TriggerConfig(mode="Rigid", params=[0, 255])
+    target = tmp_path / "atomic.json"
+
+    # Pré-grava conteúdo válido em ``target`` para confirmar invariante de
+    # "se replace falhar, conteúdo antigo permanece".
+    target.write_text('{"preexistente": true}\n', encoding="utf-8")
+    conteudo_antigo = target.read_text(encoding="utf-8")
+
+    # Patch ``Path.replace`` para levantar OSError simulando falha de IO.
+    original_replace = Path.replace
+
+    def replace_falho(self: Path, target_path: Path | str) -> Path:
+        if str(self).endswith(".json.tmp"):
+            raise OSError("falha simulada em replace")
+        return original_replace(self, target_path)
+
+    monkeypatch.setattr(Path, "replace", replace_falho)
+
+    with pytest.raises(OSError, match="falha simulada"):
+        export_trigger_preset(target, name="atomic", trigger=cfg)
+
+    # Arquivo final intocado.
+    assert target.read_text(encoding="utf-8") == conteudo_antigo
+    # Tmp pode ter sido escrito mas não promovido a final.
+    tmp_path_file = target.with_suffix(".json.tmp")
+    if tmp_path_file.exists():
+        # Conteúdo do tmp deve ser o do preset novo, garantindo atomicidade.
+        assert "atomic" in tmp_path_file.read_text(encoding="utf-8")
+
+
+def test_import_json_malformado_levanta_decodeerror(tmp_path: Path) -> None:
+    target = tmp_path / "ruim.json"
+    target.write_text("{invalido", encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        import_trigger_preset(target)
+
+
+def test_import_schema_version_invalido_levanta_validation(tmp_path: Path) -> None:
+    target = tmp_path / "v999.json"
+    raw = {
+        "schema_version": 999,
+        "name": "qualquer",
+        "exported_at": "2026-04-24T00:00:00+00:00",
+        "trigger": {"mode": "Off", "params": []},
+    }
+    target.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(ValidationError):
+        import_trigger_preset(target)
+
+
+def test_import_name_vazio_levanta_validation(tmp_path: Path) -> None:
+    target = tmp_path / "sem_nome.json"
+    raw = {
+        "schema_version": 1,
+        "name": "",
+        "exported_at": "2026-04-24T00:00:00+00:00",
+        "trigger": {"mode": "Off", "params": []},
+    }
+    target.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(ValidationError):
+        import_trigger_preset(target)
+
+
+def test_import_exported_at_invalido_levanta_validation(tmp_path: Path) -> None:
+    target = tmp_path / "ts_ruim.json"
+    raw = {
+        "schema_version": 1,
+        "name": "ok",
+        "exported_at": "ontem-de-tarde",
+        "trigger": {"mode": "Off", "params": []},
+    }
+    target.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(ValidationError):
+        import_trigger_preset(target)
+
+
+def test_import_extra_field_levanta_validation(tmp_path: Path) -> None:
+    target = tmp_path / "extra.json"
+    raw = {
+        "schema_version": 1,
+        "name": "ok",
+        "exported_at": "2026-04-24T00:00:00+00:00",
+        "trigger": {"mode": "Off", "params": []},
+        "campo_extra": "proibido",
+    }
+    target.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(ValidationError):
+        import_trigger_preset(target)
+
+
+def test_import_arquivo_inexistente_levanta_filenotfound(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        import_trigger_preset(tmp_path / "nao_existe.json")
+
+
+def test_export_grava_iso8601_com_timezone(tmp_path: Path) -> None:
+    cfg = TriggerConfig(mode="Off", params=[])
+    final = export_trigger_preset(tmp_path / "ts.json", name="ts", trigger=cfg)
+    raw = json.loads(final.read_text(encoding="utf-8"))
+    ts = raw["exported_at"]
+    assert ts.endswith("+00:00") or ts.endswith("Z")
+    # Reparseável.
+    from datetime import datetime
+    datetime.fromisoformat(ts)
+
+
+def test_preset_model_round_trip_dump_validate() -> None:
+    """Sanidade: ``model_dump(mode='json')`` -> ``model_validate`` é idempotente."""
+    preset = TriggerPreset(
+        schema_version=1,
+        name="abc",
+        exported_at="2026-04-24T00:00:00+00:00",
+        trigger=TriggerConfig(mode="Off", params=[]),
+    )
+    raw = preset.model_dump(mode="json")
+    preset2 = TriggerPreset.model_validate(raw)
+    assert preset2 == preset

--- a/tests/unit/test_triggers_actions_preset_io.py
+++ b/tests/unit/test_triggers_actions_preset_io.py
@@ -1,0 +1,384 @@
+"""Testes do mixin TriggersActionsMixin para handlers de preset IO.
+
+FEAT-TRIGGER-PRESETS-IMPORT-EXPORT-01.
+
+Cobertura:
+  - Import válido atualiza ``draft.triggers.<side>`` sem chamar ``trigger_set``.
+  - Import com arquivo malformado não altera draft nem widgets.
+  - Import em ``left`` preserva ``right`` e vice-versa.
+  - Export grava arquivo JSON com estado atual dos sliders.
+  - Export cancelado (sem nome) não cria arquivo.
+  - Round-trip via FileChooser mockado: export → import → draft idêntico.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+# Reusa stubs e fakes do test_triggers_actions (carrega instalação de gi).
+# Isso garante que o módulo gi.repository.Gtk tenha as fakes necessárias antes
+# do triggers_actions ser importado.
+from tests.unit.test_triggers_actions import (
+    _build_mixin,
+    _FakeTriggersMixin,
+)
+
+# --- Stubs adicionais para FileChooserDialog e prompt_profile_name ---------
+
+
+class _FakeFileFilter:
+    def __init__(self) -> None:
+        self.name = ""
+
+    def set_name(self, n: str) -> None:
+        self.name = n
+
+    def add_pattern(self, _p: str) -> None:
+        pass
+
+
+class _FakeFileChooser:
+    """FileChooser fake controlável por monkeypatch.
+
+    Atributos de classe permitem injetar respostas/filename a partir do teste.
+    """
+
+    last_response: int = 0  # OK
+    last_filename: str | None = None
+    last_action: int = 0
+    last_overwrite_confirm: bool = False
+    instances: ClassVar[list[Any]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.title = kwargs.get("title", "")
+        self.parent = kwargs.get("parent")
+        self.action = kwargs.get("action", 0)
+        self._buttons: list[tuple[str, int]] = []
+        self._default_response = 0
+        self._current_name = ""
+        self._filters: list[_FakeFileFilter] = []
+        self._do_overwrite_confirmation = False
+        _FakeFileChooser.instances.append(self)
+
+    def add_button(self, label: str, response: int) -> None:
+        self._buttons.append((label, response))
+
+    def set_default_response(self, r: int) -> None:
+        self._default_response = r
+
+    def set_do_overwrite_confirmation(self, v: bool) -> None:
+        self._do_overwrite_confirmation = bool(v)
+
+    def set_current_name(self, n: str) -> None:
+        self._current_name = n
+
+    def add_filter(self, f: _FakeFileFilter) -> None:
+        self._filters.append(f)
+
+    def run(self) -> int:
+        return _FakeFileChooser.last_response
+
+    def get_filename(self) -> str | None:
+        return _FakeFileChooser.last_filename
+
+    def destroy(self) -> None:
+        pass
+
+
+def _install_filechooser_stubs(
+    monkeypatch: pytest.MonkeyPatch, *, ok: bool, filename: str | None
+) -> None:
+    from gi.repository import Gtk
+
+    # Constantes de Gtk.FileChooserAction e ResponseType — sobrescrever
+    # sempre, porque outros suites podem ter instalado stubs incompletos
+    # no mesmo gi.repository.Gtk (poluição entre testes na mesma sessão).
+    Gtk.FileChooserAction = types.SimpleNamespace(OPEN=0, SAVE=1)  # type: ignore[attr-defined]
+    Gtk.ResponseType = types.SimpleNamespace(  # type: ignore[attr-defined]
+        OK=-5, CANCEL=-6, REJECT=-2,
+    )
+
+    Gtk.FileChooserDialog = _FakeFileChooser  # type: ignore[attr-defined]
+    Gtk.FileFilter = _FakeFileFilter  # type: ignore[attr-defined]
+
+    _FakeFileChooser.last_response = Gtk.ResponseType.OK if ok else Gtk.ResponseType.CANCEL
+    _FakeFileChooser.last_filename = filename
+    _FakeFileChooser.instances = []
+
+
+def _install_prompt_stub(
+    monkeypatch: pytest.MonkeyPatch, *, return_value: str | None
+) -> dict[str, Any]:
+    """Mocka ``hefesto.app.gui_dialogs.prompt_profile_name``.
+
+    Retorna dict mutável com ``calls`` para asserts.
+    """
+    info: dict[str, Any] = {"calls": 0, "last_default": None}
+
+    fake_module = sys.modules.get("hefesto.app.gui_dialogs")
+    if fake_module is None:
+        fake_module = types.ModuleType("hefesto.app.gui_dialogs")
+        sys.modules["hefesto.app.gui_dialogs"] = fake_module
+
+    def fake_prompt(parent: Any = None, default_name: str = "") -> str | None:
+        info["calls"] += 1
+        info["last_default"] = default_name
+        return return_value
+
+    fake_module.prompt_profile_name = fake_prompt  # type: ignore[attr-defined]
+    return info
+
+
+# --- Helper para anexar handlers novos ao mixin -----------------------
+
+
+def _wire_preset_io(inst: _FakeTriggersMixin) -> None:
+    """Anexa handlers de preset IO ao ``_FakeTriggersMixin`` instanciado.
+
+    O ``_build_mixin`` original só anexa handlers da Wave V2.4; sprint nova
+    adiciona métodos novos que precisam ser bindados manualmente.
+    """
+    from hefesto.app.actions import triggers_actions
+
+    cls = triggers_actions.TriggersActionsMixin
+    for name in (
+        "on_trigger_left_preset_export",
+        "on_trigger_right_preset_export",
+        "on_trigger_left_preset_import",
+        "on_trigger_right_preset_import",
+        "_handle_preset_export",
+        "_handle_preset_import",
+        "_apply_imported_preset_to_editor",
+        "_build_trigger_config_for_export",
+        "_toast_preset_io",
+    ):
+        setattr(inst, name, cls.__dict__[name].__get__(inst, type(inst)))
+
+
+# --- Testes -----------------------------------------------------------
+
+
+def test_handle_preset_import_atualiza_draft_sem_chamar_ipc(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Import válido popula draft do lado escolhido sem disparar ``trigger_set``."""
+    mixin = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin)
+    mixin.install_triggers_tab()
+
+    # Cria preset em disco.
+    preset_path = tmp_path / "rigid.json"
+    preset_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "name": "Rigid teste",
+            "exported_at": "2026-04-24T00:00:00+00:00",
+            "trigger": {"mode": "Rigid", "params": [5, 200]},
+        }),
+        encoding="utf-8",
+    )
+
+    _install_filechooser_stubs(monkeypatch, ok=True, filename=str(preset_path))
+
+    n_calls_antes = len(mixin._trigger_set_calls)  # type: ignore[attr-defined]
+    mixin.on_trigger_left_preset_import(None)
+
+    # IPC NÃO foi chamado.
+    assert len(mixin._trigger_set_calls) == n_calls_antes  # type: ignore[attr-defined]
+    # Draft refletindo preset.
+    assert mixin.draft.triggers.left.mode == "Rigid"
+    assert mixin.draft.triggers.left.params == (5, 200)
+
+
+def test_handle_preset_import_arquivo_invalido_nao_altera_draft(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mixin = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin)
+    mixin.install_triggers_tab()
+
+    # Estado inicial.
+    assert mixin.draft.triggers.left.mode == "Off"
+
+    bad_path = tmp_path / "ruim.json"
+    bad_path.write_text("{nao_e_json", encoding="utf-8")
+
+    _install_filechooser_stubs(monkeypatch, ok=True, filename=str(bad_path))
+
+    mixin.on_trigger_left_preset_import(None)
+
+    # Draft permanece em Off.
+    assert mixin.draft.triggers.left.mode == "Off"
+    assert mixin.draft.triggers.left.params == ()
+
+
+def test_handle_preset_import_em_left_preserva_right(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mixin = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin)
+    mixin.install_triggers_tab()
+
+    # Configura right num modo distinto antes do import em left.
+    from hefesto.app.draft_config import (
+        DraftConfig,
+        TriggerDraft,
+        TriggersDraft,
+    )
+
+    mixin.draft = DraftConfig(
+        triggers=TriggersDraft(
+            left=TriggerDraft(mode="Off", params=()),
+            right=TriggerDraft(mode="Pulse", params=(1, 2, 3)),
+        ),
+    )
+
+    preset_path = tmp_path / "p.json"
+    preset_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "name": "Rigid",
+            "exported_at": "2026-04-24T00:00:00+00:00",
+            "trigger": {"mode": "Rigid", "params": [5, 200]},
+        }),
+        encoding="utf-8",
+    )
+
+    _install_filechooser_stubs(monkeypatch, ok=True, filename=str(preset_path))
+
+    mixin.on_trigger_left_preset_import(None)
+
+    assert mixin.draft.triggers.left.mode == "Rigid"
+    # Right permanece intocado.
+    assert mixin.draft.triggers.right.mode == "Pulse"
+    assert mixin.draft.triggers.right.params == (1, 2, 3)
+
+
+def test_handle_preset_import_cancelado_nao_altera_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mixin = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin)
+    mixin.install_triggers_tab()
+
+    _install_filechooser_stubs(monkeypatch, ok=False, filename=None)
+    mixin.on_trigger_left_preset_import(None)
+
+    assert mixin.draft.triggers.left.mode == "Off"
+
+
+def test_handle_preset_export_grava_arquivo_com_estado_dos_sliders(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mixin = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin)
+    mixin.install_triggers_tab()
+
+    # Configura estado: modo Rigid + sliders 5/200.
+    combo = mixin._widgets["trigger_left_mode"]
+    combo.set_active_id("Rigid")
+    mixin.on_trigger_left_mode_changed(combo)
+    widgets = mixin._trigger_param_widgets["left"]
+    widgets["position"].set_value(5)
+    widgets["force"].set_value(200)
+
+    target = tmp_path / "rigid_export.json"
+    _install_filechooser_stubs(monkeypatch, ok=True, filename=str(target))
+    info = _install_prompt_stub(monkeypatch, return_value="Rigid exportado")
+
+    mixin.on_trigger_left_preset_export(None)
+
+    assert info["calls"] == 1
+    assert target.exists()
+    raw = json.loads(target.read_text(encoding="utf-8"))
+    assert raw["name"] == "Rigid exportado"
+    assert raw["trigger"]["mode"] == "Rigid"
+    assert raw["trigger"]["params"] == [5, 200]
+
+
+def test_handle_preset_export_cancelado_no_prompt_nao_cria_arquivo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mixin = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin)
+    mixin.install_triggers_tab()
+
+    combo = mixin._widgets["trigger_left_mode"]
+    combo.set_active_id("Rigid")
+    mixin.on_trigger_left_mode_changed(combo)
+
+    # Prompt retorna None (usuário cancelou nome).
+    _install_prompt_stub(monkeypatch, return_value=None)
+    target = tmp_path / "nada.json"
+    _install_filechooser_stubs(monkeypatch, ok=True, filename=str(target))
+
+    mixin.on_trigger_left_preset_export(None)
+
+    assert not target.exists()
+
+
+def test_round_trip_export_import_draft_identico(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Export do estado atual + import em outro mixin = draft idêntico."""
+    mixin = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin)
+    mixin.install_triggers_tab()
+
+    # Configura Rigid 7/180 em left.
+    combo = mixin._widgets["trigger_left_mode"]
+    combo.set_active_id("Rigid")
+    mixin.on_trigger_left_mode_changed(combo)
+    widgets = mixin._trigger_param_widgets["left"]
+    widgets["position"].set_value(7)
+    widgets["force"].set_value(180)
+
+    target = tmp_path / "rt.json"
+    _install_filechooser_stubs(monkeypatch, ok=True, filename=str(target))
+    _install_prompt_stub(monkeypatch, return_value="rt")
+
+    mixin.on_trigger_left_preset_export(None)
+    assert target.exists()
+
+    # Novo mixin, import.
+    mixin2 = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin2)
+    mixin2.install_triggers_tab()
+
+    _install_filechooser_stubs(monkeypatch, ok=True, filename=str(target))
+    mixin2.on_trigger_right_preset_import(None)
+
+    # right do mixin2 deve refletir o que estava em left do mixin.
+    assert mixin2.draft.triggers.right.mode == "Rigid"
+    assert mixin2.draft.triggers.right.params == (7, 180)
+
+
+def test_handle_preset_import_modo_off_nao_quebra(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Import de preset com mode='Off' (sem params) é aceito sem erro."""
+    mixin = _build_mixin(monkeypatch)
+    _wire_preset_io(mixin)
+    mixin.install_triggers_tab()
+
+    target = tmp_path / "off.json"
+    target.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "name": "Off",
+            "exported_at": "2026-04-24T00:00:00+00:00",
+            "trigger": {"mode": "Off", "params": []},
+        }),
+        encoding="utf-8",
+    )
+
+    _install_filechooser_stubs(monkeypatch, ok=True, filename=str(target))
+    mixin.on_trigger_right_preset_import(None)
+
+    assert mixin.draft.triggers.right.mode == "Off"
+    assert mixin.draft.triggers.right.params == ()


### PR DESCRIPTION
## Sumário

Sprint Wave V2.5 #8 — adiciona IO standalone de presets de gatilho na aba Gatilhos.

- Schema novo `TriggerPreset` (wrapper `schema_version` + `name` + `exported_at` + `TriggerConfig`) em `src/hefesto/profiles/trigger_preset_schema.py`.
- IO puro (atomic write via tmp+replace) em `src/hefesto/profiles/trigger_preset_io.py`.
- 4 botões novos no glade (`trigger_<side>_preset_<export|import>`) — 1 par por coluna L2/R2.
- 4 handlers + helpers `_handle_preset_export/_import` + `_apply_imported_preset_to_editor` em `triggers_actions.py`.
- 4 entradas novas em `_signal_handlers()` de `app.py` (anti-regressão A-7-ish).
- 21 testes novos (9 IO + 12 mixin com mocks GTK).

Invariante preservada: import é não-destrutivo — apenas popula widgets + draft do lado afetado, nunca chama `trigger_set` (IPC). Usuário ainda precisa pressionar "Aplicar em L2/R2".

## Gates

- `ruff check src/ tests/` — clean.
- `mypy src/hefesto` — 115 files, 0 erros (+1 vs baseline 114).
- `pytest tests/unit -q` — **1353 passed, 8 skipped** (baseline 1340 → +13 testes; o restante já é estabilizado).
- Acentuação periférica — passou `validar-acentuacao.py`.
- A-04 — glifos Unicode preservados em `status_actions.py` e `tui/widgets/__init__.py` (este último usa `▮▯` block elements, não `●○◐`).
- Camadas — `trigger_preset_io.py` e `trigger_preset_schema.py` não importam de `hefesto.daemon`.
- A-06 — não disparada (zero campos novos em `*Config` consumidos por mapper de perfil).

## Validação visual

Screenshot capturado pelo executor antes do polish: `/tmp/hefesto_gui_gatilhos_20260424T190813.png`
- sha256 `7b0357a955ec8f9d999ecec0f600488b3547efea5a0999f0b33795af16f5a886`.
- Mostra aba Gatilhos com nova linha `Exportar preset... / Importar preset...` em cada coluna L2/R2 (estado pré-polish; HEAD atual usa labels encurtados `Exportar... / Importar...`).
- GUI não foi recapturada porque o tray do app está em loop de crash em Pop!_OS 22 (issue separada, fora do escopo desta sprint).

## Follow-up visual (PR dedicada sucessora)

A linha extra de botões fez `GtkNotebook` adotar a altura da maior child, inflando todas as abas (crescimento vertical excessivo da janela observado em Pop!_OS 22). O fix consolida os 4 botões por coluna em uma única linha (Aplicar/Desligar/Exportar/Importar) e está testado localmente em stash; vai em **PR dedicada sucessora**. Esta PR foi mergeada com o bug visual conhecido por autorização do dono.

## Test plan

- [x] Round-trip simples (Rigid params=[0,255]).
- [x] Round-trip aninhado (MultiPositionFeedback `params=[[…],…]`).
- [x] JSON malformado levanta `JSONDecodeError`.
- [x] schema_version inválido levanta `ValidationError`.
- [x] name vazio rejeitado.
- [x] exported_at não-ISO rejeitado.
- [x] Atomic write — tmp não persiste se replace falha.
- [x] Import não chama `trigger_set` (mock).
- [x] Import em `left` não toca `right` no draft.

## Lições aplicadas

- L-21-3 (leitura código antes de spec): spec lista linhas exatas lidas em `main.glade`, `triggers_actions.py`, `schema.py`, `draft_config.py`, `footer_actions.py`.
- L-21-4 (proof-of-work runtime real): ruff + mypy + pytest todos verdes; smoke do executor reportado.