### PR TITLE
fix(gui): split aba Mouse e Teclado em duas + quit não-bloqueante

### DIFF
--- a/src/hefesto/app/app.py
+++ b/src/hefesto/app/app.py
@@ -15,6 +15,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 from typing import Any
 
 import gi
@@ -262,10 +263,27 @@ class HefestoApp(
 
         'Sair' do menu do tray encerra tudo. 'Fechar janela' (X no header)
         continua só escondendo pro tray via `on_window_delete_event`.
+
+        Ordem importa: chamamos `Gtk.main_quit()` ANTES do cleanup. O
+        `tray.stop()` faz uma call síncrona via D-Bus que pode travar
+        indefinidamente em ambientes sem StatusNotifierWatcher robusto
+        (Pop Shell sem TopIcons, COSMIC alpha etc). Se travasse antes do
+        `main_quit`, o loop GTK ficava preso e a GUI nunca encerrava. Ao
+        quitar o loop primeiro e jogar o cleanup numa thread daemon, o
+        processo sempre encerra mesmo se o cleanup nunca retornar.
         """
         self._quitting = True
-        if self.tray is not None:
-            self.tray.stop()
+        Gtk.main_quit()
+        threading.Thread(target=self._shutdown_backend, daemon=True).start()
+
+    def _shutdown_backend(self) -> None:
+        """Cleanup pós-quit (tray + daemon systemd). Pode travar sem
+        reter o processo porque a thread é daemon."""
+        try:
+            if self.tray is not None:
+                self.tray.stop()
+        except Exception as exc:
+            logger.warning("quit_app_tray_stop_falhou", erro=str(exc))
         try:
             subprocess.run(
                 ["systemctl", "--user", "stop", "hefesto.service"],
@@ -275,7 +293,6 @@ class HefestoApp(
             )
         except (FileNotFoundError, subprocess.SubprocessError) as exc:
             logger.warning("quit_app_systemctl_falhou", erro=str(exc))
-        Gtk.main_quit()
 
     def show_window(self) -> None:
         self.window.show_all()

--- a/src/hefesto/gui/main.glade
+++ b/src/hefesto/gui/main.glade
@@ -1712,7 +1712,7 @@ Transições com debounce de 5 segundos para evitar oscilação.</property>
               <object class="GtkLabel"><property name="label">Emulação</property></object>
             </child>
 
-            <!-- Aba Mouse -->
+            <!-- Aba Mouse (somente emulação de mouse — Teclado é aba separada) -->
             <child>
               <object class="GtkBox" id="tab_mouse">
                 <property name="orientation">vertical</property>
@@ -1940,17 +1940,24 @@ Transições com debounce de 5 segundos para evitar oscilação.</property>
                   </object>
                   <packing><property name="expand">False</property></packing>
                 </child>
+              </object>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel"><property name="label">Mouse</property></object>
+            </child>
 
-                <!-- FEAT-KEYBOARD-UI-01: seção de Teclado (bindings por perfil) -->
-                <child>
-                  <object class="GtkSeparator">
-                    <property name="orientation">horizontal</property>
-                  </object>
-                  <packing><property name="expand">False</property></packing>
-                </child>
+            <!-- Aba Teclado (FEAT-KEYBOARD-UI-01 separada de Mouse para
+                 enxugar min-size do notebook — antes ambas viviam numa única
+                 aba "Mouse e Teclado" e a soma de mapeamento + treeview
+                 inflava a altura natural de todas as outras abas). -->
+            <child>
+              <object class="GtkBox" id="tab_keyboard">
+                <property name="orientation">vertical</property>
+                <property name="margin">12</property>
+                <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="label">&lt;b&gt;Teclado (bindings do perfil ativo)&lt;/b&gt;</property>
+                    <property name="label">&lt;b&gt;Bindings do perfil ativo&lt;/b&gt;</property>
                     <property name="use-markup">True</property>
                     <property name="xalign">0</property>
                   </object>
@@ -1970,7 +1977,7 @@ Transições com debounce de 5 segundos para evitar oscilação.</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="shadow-type">in</property>
-                    <property name="min-content-height">200</property>
+                    <property name="min-content-height">160</property>
                     <child>
                       <object class="GtkTreeView" id="key_bindings_treeview">
                         <property name="visible">True</property>
@@ -2014,7 +2021,7 @@ Transições com debounce de 5 segundos para evitar oscilação.</property>
               </object>
             </child>
             <child type="tab">
-              <object class="GtkLabel"><property name="label">Mouse e Teclado</property></object>
+              <object class="GtkLabel"><property name="label">Teclado</property></object>
             </child>
 
             <!-- Aba Firmware -->

--- a/tests/unit/test_quit_app_stops_daemon.py
+++ b/tests/unit/test_quit_app_stops_daemon.py
@@ -23,6 +23,29 @@ def _load_app_module():
     return app_mod
 
 
+class _InstantThread:
+    """Stub de threading.Thread que executa target() síncrono em start().
+
+    Preserva a assinatura esperada (target, daemon kwarg) mas roda na
+    thread principal pra facilitar asserts nos testes. quit_app dispara
+    `_shutdown_backend` em thread daemon; usar este stub vira execução
+    in-line.
+    """
+
+    def __init__(self, target=None, daemon=False, **_kw):
+        self._target = target
+
+    def start(self) -> None:
+        if self._target is not None:
+            self._target()
+
+
+def _make_quit_stub(app_mod, tray=None):
+    stub = SimpleNamespace(_quitting=False, tray=tray)
+    stub._shutdown_backend = lambda: app_mod.HefestoApp._shutdown_backend(stub)
+    return stub
+
+
 def test_quit_app_chama_systemctl_stop(monkeypatch):
     app_mod = _load_app_module()
 
@@ -31,8 +54,9 @@ def test_quit_app_chama_systemctl_stop(monkeypatch):
 
     monkeypatch.setattr(app_mod.subprocess, "run", fake_run)
     monkeypatch.setattr(app_mod.Gtk, "main_quit", fake_main_quit)
+    monkeypatch.setattr(app_mod.threading, "Thread", _InstantThread)
 
-    stub = SimpleNamespace(_quitting=False, tray=None)
+    stub = _make_quit_stub(app_mod)
     app_mod.HefestoApp.quit_app(stub)
 
     fake_run.assert_called_once()
@@ -55,8 +79,9 @@ def test_quit_app_sobrevive_a_systemctl_ausente(monkeypatch):
 
     monkeypatch.setattr(app_mod.subprocess, "run", _raise)
     monkeypatch.setattr(app_mod.Gtk, "main_quit", fake_main_quit)
+    monkeypatch.setattr(app_mod.threading, "Thread", _InstantThread)
 
-    stub = SimpleNamespace(_quitting=False, tray=None)
+    stub = _make_quit_stub(app_mod)
     app_mod.HefestoApp.quit_app(stub)
     fake_main_quit.assert_called_once()
 
@@ -70,8 +95,9 @@ def test_quit_app_para_tray(monkeypatch):
 
     monkeypatch.setattr(app_mod.subprocess, "run", fake_run)
     monkeypatch.setattr(app_mod.Gtk, "main_quit", fake_main_quit)
+    monkeypatch.setattr(app_mod.threading, "Thread", _InstantThread)
 
-    stub = SimpleNamespace(_quitting=False, tray=fake_tray)
+    stub = _make_quit_stub(app_mod, tray=fake_tray)
     app_mod.HefestoApp.quit_app(stub)
 
     fake_tray.stop.assert_called_once()
@@ -87,7 +113,41 @@ def test_quit_app_sobrevive_a_timeout(monkeypatch):
 
     monkeypatch.setattr(app_mod.subprocess, "run", _timeout)
     monkeypatch.setattr(app_mod.Gtk, "main_quit", fake_main_quit)
+    monkeypatch.setattr(app_mod.threading, "Thread", _InstantThread)
 
-    stub = SimpleNamespace(_quitting=False, tray=None)
+    stub = _make_quit_stub(app_mod)
     app_mod.HefestoApp.quit_app(stub)
     fake_main_quit.assert_called_once()
+
+
+def test_quit_app_main_quit_antes_do_cleanup(monkeypatch):
+    """Invariante crítico: Gtk.main_quit é chamado ANTES de tray.stop /
+    systemctl pra que o processo encerre mesmo se o cleanup travar
+    (D-Bus sem StatusNotifierWatcher robusto)."""
+    app_mod = _load_app_module()
+
+    call_order: list[str] = []
+
+    def _record_quit() -> None:
+        call_order.append("main_quit")
+
+    fake_tray = MagicMock()
+    fake_tray.stop.side_effect = lambda: call_order.append("tray_stop")
+
+    fake_run = MagicMock(
+        side_effect=lambda *_a, **_kw: (
+            call_order.append("systemctl"),
+            SimpleNamespace(returncode=0),
+        )[1]
+    )
+
+    monkeypatch.setattr(app_mod.Gtk, "main_quit", _record_quit)
+    monkeypatch.setattr(app_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(app_mod.threading, "Thread", _InstantThread)
+
+    stub = _make_quit_stub(app_mod, tray=fake_tray)
+    app_mod.HefestoApp.quit_app(stub)
+
+    assert call_order[0] == "main_quit"
+    assert "tray_stop" in call_order
+    assert "systemctl" in call_order


### PR DESCRIPTION
## Summary
Dois bugs detectados em validação manual no Pop!_OS 22 (Mutter + Pop Shell), atacados juntos:

### 1. Aba "Mouse e Teclado" inflava todas as abas
A aba carregava sliders + frame Mapeamento (8 linhas) + TreeView (min-content-height=200) + 3 botões CRUD = ~1000 px de altura natural. `GtkNotebook` propaga o maior child pro `WM_NORMAL_HINTS` do toplevel, então **todas** as abas pediam essa altura — empurrando a janela além da dock em telas modestas.

**Fix**: split em duas abas:
- **Mouse**: toggle, sliders, frame Mapeamento, nota udev
- **Teclado**: legenda, TreeView, botões CRUD

Bonus: `min-content-height` da TreeView 200 → 160.

**Resultado empírico:** janela cai de **1390x1092 → 1178x818** (~30% menor) sem outras mudanças.

### 2. "Sair" no tray não encerrava o processo
`tray.stop()` chama `indicator.set_status(PASSIVE)` via D-Bus síncrono que trava em ambientes sem StatusNotifierWatcher robusto (Pop Shell sem TopIcons, COSMIC alpha). Quando travava ANTES do `Gtk.main_quit()`, o loop ficava preso e era necessário Ctrl+C.

**Fix**: `Gtk.main_quit()` primeiro, cleanup em `threading.Thread(daemon=True)`. Daemon thread não retém o processo. +1 teste invariante (`test_quit_app_main_quit_antes_do_cleanup`).

## Evidência
- `WM_NORMAL_HINTS` `minimum size` antes: 1390x1092 → depois: 1178x818
- 10 abas visíveis no notebook: Status, Gatilhos, Lightbar, Rumble, Perfis, Daemon, Emulação, **Mouse**, **Teclado**, Firmware

## Test plan
- [x] `pytest tests/unit -q` → 1286 passed, 9 skipped
- [x] `ruff check src/ tests/` → clean
- [x] `mypy src/hefesto` → 111 files, zero errors
- [x] Visual cross-tab: janela 1178x818, todas as abas presentes (screenshot capturado)
- [ ] Validação manual no Pop!_OS 22:
  - Aba Mouse mostra sliders + Mapeamento sem TreeView
  - Aba Teclado mostra TreeView + Adicionar/Remover/Restaurar
  - "Sair" no menu do tray encerra GUI + daemon sem Ctrl+C
  - Janela abre sem encostar na dock

🤖 Generated with [Claude Code](https://claude.com/claude-code)