### PR TITLE
fix(gui): contraste do popup combobox na aba Gatilhos (BUG-GUI-COMBOBOX-POPUP-CONTRAST-01)

### DIFF
--- a/src/hefesto_dualsense4unix/gui/theme.css
+++ b/src/hefesto_dualsense4unix/gui/theme.css
@@ -50,6 +50,36 @@
 .hefesto-dualsense4unix-window combobox arrow {
     color: #bd93f9;
 }
+
+/* Popup interno do GtkComboBoxText. O popup é uma window separada (filha do
+   screen) que não herda escopo do .hefesto-dualsense4unix-window — precisa
+   selector próprio. Cobre ambas variantes: appears-as-list=true (treeview)
+   e false (menuitem). Sem isso, o popup herda o tema GTK do sistema (claro
+   em Pop!_OS GNOME) e o texto fica ilegível sobre o fundo Drácula.
+   BUG-GUI-COMBOBOX-POPUP-CONTRAST-01. */
+combobox window.popup,
+combobox window.popup decoration,
+combobox > window {
+    background-color: #282a36;
+    border: 1px solid #6272a4;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+combobox window menuitem,
+combobox window menuitem label,
+combobox window cellview,
+combobox window treeview,
+combobox window treeview.view {
+    background-color: #282a36;
+    color: #f8f8f2;
+    padding: 4px 8px;
+}
+combobox window menuitem:hover,
+combobox window menuitem:hover label,
+combobox window treeview:selected,
+combobox window treeview.view:selected {
+    background-color: #44475a;
+    color: #f8f8f2;
+}
 /* Labels gerais — herdam color via .hefesto-dualsense4unix-window mas em alguns
    containers internos (Frame, Box) o GTK aplica cinza disabled-look. Forçar. */
 .hefesto-dualsense4unix-window label {


### PR DESCRIPTION
## Sintoma

Aba Gatilhos (e demais com `GtkComboBoxText`): ao abrir o dropdown, o popup interno herdava o tema GTK do sistema (claro em Pop!_OS GNOME), produzindo texto cinza sobre fundo cinza nos itens.

## Causa

O popup do `GtkComboBoxText` é uma `GtkWindow` separada (filha do screen, override-redirect) que não herda o escopo `.hefesto-dualsense4unix-window` declarado em `theme.css`. As regras existentes só atingiam o botão visível.

## Fix

`src/hefesto_dualsense4unix/gui/theme.css` ganhou regras para `combobox window.popup`, `combobox window menuitem`, `combobox window treeview` e estados `:hover`/`:selected`, com paleta Drácula:

- bg do popup: `#282a36`
- fg dos itens: `#f8f8f2`
- bg item selecionado: `#44475a`
- border: `#6272a4`

Cobre ambas variantes (`appears-as-list=true|false`).

## Validação

- Sintaxe CSS: parse limpo via `Gtk.CssProvider.load_from_data` (sem `parsing-error`).
- `ruff check src/ tests/`: All checks passed.
- `./scripts/check_anonymity.sh`: OK.

**Validação manual pendente** (xdotool não conseguiu disparar `popup` do combobox via XTEST events em GTK3 + GNOME 42): abrir GUI, navegar à aba Gatilhos, clicar em "Modo:" — texto branco sobre fundo escuro com hover em `#44475a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)