### PR TITLE
fix(systemd): autostart unit ancora em default.target (BUG-DEB-AUTOSTART-WANTEDBY-DEFAULT-01)

### DIFF
--- a/assets/hefesto-dualsense4unix.service
+++ b/assets/hefesto-dualsense4unix.service
@@ -1,7 +1,10 @@
 [Unit]
 Description=Hefesto - Dualsense4Unix DualSense adaptive trigger daemon
-After=graphical-session.target
-PartOf=graphical-session.target
+# BUG-DEB-AUTOSTART-WANTEDBY-DEFAULT-01: o daemon usa /dev/hidraw e evdev,
+# não depende de DISPLAY/Wayland/X11. Ancorar em default.target garante
+# autostart resiliente em qualquer DE (GNOME/KDE/Sway/i3) e elimina race
+# entre login e graphical-session activation. After= preservado por ordem.
+After=graphical-session.target default.target
 # BUG-MULTI-INSTANCE-01: teto anti-loop em Unit. Máximo 3 tentativas em 30s —
 # se estourar, systemd marca failed e pára de respawnar.
 StartLimitIntervalSec=30
@@ -18,4 +21,4 @@ SuccessExitStatus=143 SIGTERM
 Environment=PYTHONUNBUFFERED=1
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=default.target

--- a/src/hefesto_dualsense4unix/cli/app.py
+++ b/src/hefesto_dualsense4unix/cli/app.py
@@ -131,7 +131,7 @@ def daemon_install_service(
     enable: bool = typer.Option(
         False,
         "--enable",
-        help="Habilitar auto-start no boot (WantedBy=graphical-session.target).",
+        help="Habilitar auto-start no boot (WantedBy=default.target).",
     ),
 ) -> None:
     """Copia a unit systemd --user `hefesto-dualsense4unix.service`.


### PR DESCRIPTION
## Sintoma

Switch \"Iniciar com o sistema\" da GUI, quando ligado pela instalação via .deb, voltava DESLIGADO após reboot. Em instalação via `install.sh` o switch persistia.

## Investigação

Hipótese inicial — \"`.deb` não copiava o `.service`\" — falsificada empiricamente: o fix do path está em commit `848660c` (incluso em `v3.0.0`). O `.service` está em `/usr/lib/systemd/user/hefesto-dualsense4unix.service`, e `systemctl --user enable` cria symlink em homedir.

## Causa real

A unit declarava `WantedBy=graphical-session.target`. O symlink era criado em `~/.config/systemd/user/graphical-session.target.wants/`. Esse target depende de o DE (gnome-session) ativá-lo, e tem race com login. Em algumas configurações o target não ativa cedo o suficiente, e o daemon nunca sobe.

## Fix

- `WantedBy=default.target` (ativada incondicionalmente pelo `systemd-user`).
- `PartOf=graphical-session.target` removido (daemon não usa DISPLAY/Wayland/X11; usa /dev/hidraw + evdev).
- `After=graphical-session.target default.target` mantido para ordem.
- `hefesto-dualsense4unix-gui-hotplug.service` PRESERVADO em `graphical-session.target` — essa SIM precisa de sessão gráfica.
- Texto do `--help` do CLI ajustado.

## Validação empírica

\`\`\`
\$ sudo apt install --reinstall ./dist/hefesto-dualsense4unix_3.0.0_amd64.deb
\$ systemctl --user enable hefesto-dualsense4unix.service
Created symlink ...config/systemd/user/default.target.wants/hefesto-dualsense4unix.service
\$ systemctl --user is-enabled hefesto-dualsense4unix.service
enabled
\$ systemctl --user daemon-reexec   # simula respawn do user manager
\$ systemctl --user is-enabled hefesto-dualsense4unix.service
enabled
\`\`\`

- pytest: 15 passed, 10 skipped (test_service_install + test_daemon_autostart + test_quit_app_stops_daemon)
- ruff + check_anonymity: OK

**Validação final pendente do usuário**: reinstalar `.deb`, ligar switch, reboot real, confirmar persistência.

🤖 Generated with [Claude Code](https://claude.com/claude-code)