### PR TITLE
fix(gui): resolver de glyphs aprende path do .deb (BUG-DEB-GLYPHS-PATH-RESOLVER-01)

### DIFF
--- a/src/hefesto_dualsense4unix/gui/widgets/button_glyph.py
+++ b/src/hefesto_dualsense4unix/gui/widgets/button_glyph.py
@@ -6,9 +6,11 @@ Cada glyph possui duas variantes carregadas em memoria na inicialização:
 
 O widget alterna entre elas via `set_pressed(bool)`, acionando `queue_draw`.
 
-Caminho dos assets resolvido por ordem de preferência:
-  1. ~/.local/share/hefesto-dualsense4unix/glyphs/   (instalação via install.sh)
-  2. assets/glyphs/                   (diretório do repo — ambiente dev)
+Caminho dos assets resolvido por ordem de preferência (BUG-DEB-GLYPHS-
+PATH-RESOLVER-01: o .deb instala em /usr/share/, não em ~/.local/share/):
+  1. ~/.local/share/hefesto-dualsense4unix/glyphs/    (install.sh nativo)
+  2. /usr/share/hefesto-dualsense4unix/assets/glyphs/ (.deb / system-wide)
+  3. assets/glyphs/                                   (diretório do repo)
 """
 from __future__ import annotations
 
@@ -48,17 +50,26 @@ BUTTON_GLYPH_LABELS: dict[str, str] = {
 
 
 def _resolver_dir_glyphs() -> pathlib.Path:
-    """Retorna o diretório de glyphs disponivel."""
-    instalado = pathlib.Path.home() / ".local" / "share" / "hefesto-dualsense4unix" / "glyphs"
-    if instalado.is_dir():
-        return instalado
-    # Dev: caminho relativo ao pacote (src/hefesto_dualsense4unix/gui/widgets/ -> raiz/assets/glyphs/)  # noqa: E501
-    repo_root = pathlib.Path(__file__).parent.parent.parent.parent.parent
-    dev = repo_root / "assets" / "glyphs"
-    if dev.is_dir():
-        return dev
+    """Retorna o diretório de glyphs disponivel.
+
+    Cobre 3 cenários de instalação. A ordem reflete preferência: usuário
+    ganha de sistema (override pessoal); sistema ganha de dev fallback.
+    """
+    candidatos: list[pathlib.Path] = [
+        # 1) install.sh nativo copia para ~/.local/share/
+        pathlib.Path.home() / ".local" / "share" / "hefesto-dualsense4unix" / "glyphs",
+        # 2) .deb instala assets em /usr/share/hefesto-dualsense4unix/assets/
+        pathlib.Path("/usr/share/hefesto-dualsense4unix/assets/glyphs"),
+        # 3) Dev: caminho relativo ao pacote
+        # (src/hefesto_dualsense4unix/gui/widgets/ -> raiz/assets/glyphs/)
+        pathlib.Path(__file__).parent.parent.parent.parent.parent / "assets" / "glyphs",
+    ]
+    for cand in candidatos:
+        if cand.is_dir():
+            return cand
     raise FileNotFoundError(
-        f"Diretório de glyphs não encontrado em '{instalado}' nem em '{dev}'."
+        "Diretório de glyphs não encontrado em nenhum dos paths: "
+        + ", ".join(str(p) for p in candidatos)
     )
 
 


### PR DESCRIPTION
## Sintoma

Na aba Status, painel \"Sticks e botões\", os glyphs físicos (✕ ○ □ △, setas D-pad, L1/R1/L2/R2, share/menu/PS/touchpad) sumiram após reinstalar o `.deb`.

## Investigação

Suspeita inicial: regras CSS de `BUG-GUI-COMBOBOX-POPUP-CONTRAST-01` (PR #104). **Falsa** — as regras só atingem `combobox window ...`.

Causa real: `_resolver_dir_glyphs()` em `src/hefesto_dualsense4unix/gui/widgets/button_glyph.py` só procurava em:

1. `~/.local/share/hefesto-dualsense4unix/glyphs/` (install.sh nativo)
2. `<repo_root>/assets/glyphs/` (dev fallback)

O `.deb` instala em `/usr/share/hefesto-dualsense4unix/assets/glyphs/` — esse path não existia na lista. Quando o pacote roda do venv bundlado em `/opt/` (PR #106), o path dev relativo aponta para `/opt/.../python3.10/assets/glyphs/` (não existe). Hosts sem install.sh prévio caem em `GLYPHS_DIR=None`, `ButtonGlyph` carrega `pixbuf=None`, `_on_draw` retorna sem desenhar.

## Fix

Lista de candidatos atualizada para incluir o path do .deb. Ordem preserva preferência: usuário (`~/.local/share`) > sistema (`/usr/share`) > dev fallback.

## Validação empírica

\`\`\`
\$ /opt/hefesto-dualsense4unix/venv/bin/python -c \\
    'from hefesto_dualsense4unix.gui.widgets.button_glyph import GLYPHS_DIR; print(GLYPHS_DIR)'
/usr/share/hefesto-dualsense4unix/assets/glyphs

\$ pytest -k 'button_glyph or glyph'  →  88 passed
\$ ruff check src/hefesto_dualsense4unix/gui/widgets/  →  All checks passed
\`\`\`

Captura visual com `.deb` reinstalado e GUI maximizada: 16 glyphs físicos restaurados em layout 4x4 no painel \"Sticks e botões\".

## Independência dos PRs irmãos

Esse fix é **independente** dos PRs #104, #105 e #106 — beneficia qualquer instalação `.deb` (atual ou anteriores) sem `~/.local/share/` preexistente. Pode ser merged em qualquer ordem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)